### PR TITLE
feat(tui): componentize task panes and form interactions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbles v0.21.1 h1:nj0decPiixaZeL9diI4uzzQTkkz1kYY8+jgzCZXSmW0=
 github.com/charmbracelet/bubbles v0.21.1/go.mod h1:HHvIYRCpbkCJw2yo0vNX1O5loCwSr9/mWS8GYSg50Sk=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -16,6 +20,8 @@ github.com/charmbracelet/x/ansi v0.11.5 h1:NBWeBpj/lJPE3Q5l+Lusa4+mH6v7487OP8K0r
 github.com/charmbracelet/x/ansi v0.11.5/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=

--- a/internal/tui/components_form.go
+++ b/internal/tui/components_form.go
@@ -1,0 +1,37 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+const (
+	modalOuterPad     = 2
+	modalMinWidth     = 52
+	modalMinInput     = 1
+	modalInputPad     = 8
+	modalWidthNum     = 2
+	modalWidthDen     = 3
+	modalMinBodyWidth = 1
+)
+
+func (m model) renderTaskFormModal() string {
+	bodyWidth := m.layout.listWidth
+	if !m.layout.narrow {
+		bodyWidth = m.layout.listWidth + m.layout.detailWidth
+	}
+	bodyWidth = max(modalMinBodyWidth, bodyWidth)
+
+	availableWidth := max(modalMinBodyWidth, bodyWidth-modalOuterPad)
+	preferredWidth := max(modalMinWidth, (bodyWidth*modalWidthNum)/modalWidthDen)
+	modalWidth := min(availableWidth, preferredWidth)
+	modalInputWidth := max(modalMinInput, modalWidth-modalInputPad)
+
+	form := m.taskForm.withWidth(modalInputWidth)
+	content := m.styles.panelFocus.Width(modalWidth).Render(form.render(m.styles))
+
+	return lipgloss.Place(
+		bodyWidth,
+		m.layout.bodyHeight,
+		lipgloss.Center,
+		lipgloss.Center,
+		content,
+	)
+}

--- a/internal/tui/components_list.go
+++ b/internal/tui/components_list.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/mholtzscher/ugh/internal/store"
+)
+
+const (
+	panelPadW = 4
+	panelPadH = 2
+
+	tableIDWidth     = 4
+	tableStateWidth  = 8
+	tableDueWidth    = 10
+	tableMinTitle    = 8
+	tableGutterState = 6
+	tableGutterBasic = 4
+)
+
+func newTaskTable(styleSet styles, layout layoutSpec) table.Model {
+	tableStyles := table.DefaultStyles()
+	tableStyles.Header = styleSet.muted.Bold(true)
+	tableStyles.Cell = lipgloss.NewStyle()
+	tableStyles.Selected = styleSet.selected
+
+	taskTable := table.New(
+		table.WithFocused(false),
+		table.WithStyles(tableStyles),
+		table.WithHeight(max(layoutMinBodyHeight, layout.bodyHeight-panelPadH)),
+		table.WithWidth(max(layoutMinNarrowListWidth, layout.listWidth-panelPadW)),
+	)
+	taskTable.KeyMap = table.KeyMap{}
+	taskTable.Help = help.New()
+
+	return taskTable
+}
+
+func taskTableRows(tasks []*store.Task, showState bool) []table.Row {
+	rows := make([]table.Row, 0, len(tasks))
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		if showState {
+			rows = append(rows, table.Row{
+				strconv.FormatInt(task.ID, 10),
+				string(task.State),
+				dueText(task),
+				task.Title,
+			})
+			continue
+		}
+
+		rows = append(rows, table.Row{
+			strconv.FormatInt(task.ID, 10),
+			dueText(task),
+			task.Title,
+		})
+	}
+	return rows
+}
+
+func taskTableColumns(showState bool, totalWidth int) []table.Column {
+	if showState {
+		titleWidth := max(tableMinTitle, totalWidth-(tableIDWidth+tableStateWidth+tableDueWidth+tableGutterState))
+		return []table.Column{
+			{Title: "ID", Width: tableIDWidth},
+			{Title: "State", Width: tableStateWidth},
+			{Title: "Due", Width: tableDueWidth},
+			{Title: "Task", Width: titleWidth},
+		}
+	}
+
+	titleWidth := max(tableMinTitle, totalWidth-(tableIDWidth+tableDueWidth+tableGutterBasic))
+	return []table.Column{
+		{Title: "ID", Width: tableIDWidth},
+		{Title: "Due", Width: tableDueWidth},
+		{Title: "Task", Width: titleWidth},
+	}
+}
+
+func setTaskTableData(taskTable *table.Model, columns []table.Column, rows []table.Row, cursor int) {
+	if len(taskTable.Columns()) != len(columns) {
+		taskTable.SetRows(nil)
+	}
+
+	taskTable.SetColumns(columns)
+	taskTable.SetRows(rows)
+	taskTable.SetCursor(cursor)
+}

--- a/internal/tui/components_shell.go
+++ b/internal/tui/components_shell.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func newHelpModel(styleSet styles, width int) help.Model {
+	helpModel := help.New()
+	helpModel.Width = width
+	helpModel.Styles.ShortKey = styleSet.key
+	helpModel.Styles.ShortDesc = styleSet.foot
+	helpModel.Styles.ShortSeparator = styleSet.separator
+	helpModel.Styles.FullKey = styleSet.key
+	helpModel.Styles.FullDesc = styleSet.foot
+	helpModel.Styles.FullSeparator = styleSet.separator
+	helpModel.Styles.Ellipsis = styleSet.muted
+	return helpModel
+}
+
+func newSpinnerModel(styleSet styles) spinner.Model {
+	spinnerModel := spinner.New(spinner.WithSpinner(spinner.Dot))
+	spinnerModel.Style = styleSet.key
+	return spinnerModel
+}
+
+func (m model) renderTabs() string {
+	renderTab := func(active bool, label string) string {
+		if active {
+			return m.styles.tabActive.Render(label)
+		}
+		return m.styles.tabPassive.Render(label)
+	}
+
+	parts := make([]string, 0, len(m.tabs))
+	for i, tab := range m.tabs {
+		label := fmt.Sprintf("%s (%d)", tab.label, tab.count)
+		parts = append(parts, renderTab(i == m.tabSelected, label))
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Left, parts...)
+}
+
+func (m model) renderStatusLine() string {
+	if m.errText != "" {
+		return m.styles.errorText.Render(m.errText)
+	}
+
+	var parts []string
+	if m.loading {
+		parts = append(parts, m.spinner.View())
+	}
+	if strings.TrimSpace(m.status) != "" {
+		parts = append(parts, m.status)
+	}
+	if filterText := strings.TrimSpace(m.filters.statusText()); filterText != "" {
+		parts = append(parts, filterText)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return m.styles.foot.Render(strings.Join(parts, "  "))
+}
+
+func (m model) renderFooter() string {
+	helpModel := m.help
+	helpModel.Width = m.viewportW
+	return helpModel.ShortHelpView(m.keys.ShortHelp())
+}
+
+func (m model) renderHelp() string {
+	helpModel := m.help
+	helpModel.Width = m.viewportW
+	return m.styles.help.Render(helpModel.FullHelpView(m.keys.FullHelp()))
+}

--- a/internal/tui/filters.go
+++ b/internal/tui/filters.go
@@ -1,30 +1,21 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/mholtzscher/ugh/internal/service"
-)
-
-type completionFilter int
-
-const (
-	completionTodo completionFilter = iota
-	completionAll
-	completionDone
+	"github.com/mholtzscher/ugh/internal/store"
 )
 
 type listFilters struct {
-	completion completionFilter
-	state      string
-	project    string
-	context    string
-	search     string
+	state   string
+	project string
+	context string
+	search  string
 }
 
 func defaultFiltersWithState(state string) listFilters {
-	return listFilters{completion: completionTodo, state: state}
+	return listFilters{state: state}
 }
 
 func (f listFilters) toListTasksRequest() service.ListTasksRequest {
@@ -35,12 +26,12 @@ func (f listFilters) toListTasksRequest() service.ListTasksRequest {
 		Search:  f.search,
 	}
 
-	switch f.completion {
-	case completionAll:
+	switch f.state {
+	case "":
 		req.All = true
-	case completionDone:
+	case string(store.StateDone):
 		req.DoneOnly = true
-	case completionTodo:
+	default:
 		req.TodoOnly = true
 	}
 
@@ -48,54 +39,23 @@ func (f listFilters) toListTasksRequest() service.ListTasksRequest {
 }
 
 func (f listFilters) toListTagsRequest() service.ListTagsRequest {
-	req := service.ListTagsRequest{}
+	var req service.ListTagsRequest
 
-	switch f.completion {
-	case completionAll:
+	switch f.state {
+	case "":
 		req.All = true
-	case completionDone:
+	case string(store.StateDone):
 		req.DoneOnly = true
-	case completionTodo:
+	default:
 		req.TodoOnly = true
 	}
 
 	return req
 }
 
-func (f listFilters) completionText() string {
-	switch f.completion {
-	case completionAll:
-		return "all"
-	case completionDone:
-		return "done"
-	case completionTodo:
-		return "todo"
-	default:
-		return "todo"
-	}
-}
-
-func (f listFilters) cycleCompletion() listFilters {
-	next := f
-	switch f.completion {
-	case completionTodo:
-		next.completion = completionAll
-	case completionAll:
-		next.completion = completionDone
-	case completionDone:
-		next.completion = completionTodo
-	default:
-		next.completion = completionTodo
-	}
-	return next
-}
-
 func (f listFilters) statusText() string {
-	parts := []string{fmt.Sprintf("mode:%s", f.completionText())}
+	parts := []string{}
 
-	if f.state != "" {
-		parts = append(parts, "state:"+f.state)
-	}
 	if f.project != "" {
 		parts = append(parts, "project:"+f.project)
 	}

--- a/internal/tui/filters_test.go
+++ b/internal/tui/filters_test.go
@@ -4,46 +4,78 @@ package tui
 import "testing"
 
 func TestListFiltersToListTasksRequest(t *testing.T) {
-	filters := listFilters{
-		completion: completionTodo,
-		state:      "now",
-		project:    "work",
-		context:    "office",
-		search:     "alpha",
+	tests := []struct {
+		name     string
+		state    string
+		wantAll  bool
+		wantDone bool
+		wantTodo bool
+	}{
+		{name: "state tab uses todo", state: "now", wantTodo: true},
+		{name: "done tab uses done only", state: "done", wantDone: true},
+		{name: "all tab uses all", state: "", wantAll: true},
 	}
 
-	req := filters.toListTasksRequest()
-	if !req.TodoOnly {
-		t.Fatal("expected TodoOnly request")
-	}
-	if req.State != "now" || req.Project != "work" || req.Context != "office" || req.Search != "alpha" {
-		t.Fatalf("unexpected request filters: %+v", req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filters := listFilters{
+				state:   tt.state,
+				project: "work",
+				context: "office",
+				search:  "alpha",
+			}
+
+			req := filters.toListTasksRequest()
+			if req.All != tt.wantAll || req.DoneOnly != tt.wantDone || req.TodoOnly != tt.wantTodo {
+				t.Fatalf(
+					"unexpected completion flags: all=%v doneOnly=%v todoOnly=%v",
+					req.All,
+					req.DoneOnly,
+					req.TodoOnly,
+				)
+			}
+			if req.State != tt.state || req.Project != "work" || req.Context != "office" || req.Search != "alpha" {
+				t.Fatalf("unexpected request filters: %+v", req)
+			}
+		})
 	}
 }
 
-func TestCycleCompletion(t *testing.T) {
-	f := listFilters{completion: completionTodo}
-	f = f.cycleCompletion()
-	if f.completion != completionAll {
-		t.Fatalf("expected completionAll, got %v", f.completion)
+func TestListFiltersToListTagsRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    string
+		wantAll  bool
+		wantDone bool
+		wantTodo bool
+	}{
+		{name: "state tab uses todo", state: "now", wantTodo: true},
+		{name: "done tab uses done only", state: "done", wantDone: true},
+		{name: "all tab uses all", state: "", wantAll: true},
 	}
-	f = f.cycleCompletion()
-	if f.completion != completionDone {
-		t.Fatalf("expected completionDone, got %v", f.completion)
-	}
-	f = f.cycleCompletion()
-	if f.completion != completionTodo {
-		t.Fatalf("expected completionTodo, got %v", f.completion)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := (listFilters{state: tt.state}).toListTagsRequest()
+			if req.All != tt.wantAll || req.DoneOnly != tt.wantDone || req.TodoOnly != tt.wantTodo {
+				t.Fatalf(
+					"unexpected completion flags: all=%v doneOnly=%v todoOnly=%v",
+					req.All,
+					req.DoneOnly,
+					req.TodoOnly,
+				)
+			}
+		})
 	}
 }
 
 func TestStatusTextIncludesSearch(t *testing.T) {
-	f := listFilters{completion: completionAll, search: "pilot"}
+	f := listFilters{search: "pilot"}
 	text := f.statusText()
 	if text == "" {
 		t.Fatal("expected non-empty status text")
 	}
-	if text != "mode:all search:pilot" {
+	if text != "search:pilot" {
 		t.Fatalf("unexpected status text: %q", text)
 	}
 }

--- a/internal/tui/forms_task_test.go
+++ b/internal/tui/forms_task_test.go
@@ -1,0 +1,14 @@
+//nolint:testpackage // Tests validate internal task form behavior directly.
+package tui
+
+import "testing"
+
+func TestTaskFormCommitNotesFromTextarea(t *testing.T) {
+	form := startAddTaskForm(40).withField(taskFormFieldNotes)
+	form.notes.SetValue("line one\nline two")
+
+	updated := form.commitInput()
+	if updated.values.notes != "line one\nline two" {
+		t.Fatalf("unexpected notes value: %q", updated.values.notes)
+	}
+}

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -3,57 +3,82 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	Quit            key.Binding
-	Help            key.Binding
-	NextView        key.Binding
-	PrevView        key.Binding
-	Refresh         key.Binding
-	Up              key.Binding
-	Down            key.Binding
-	Top             key.Binding
-	Bottom          key.Binding
-	Select          key.Binding
-	CycleCompletion key.Binding
-	Search          key.Binding
-	ProjectFilter   key.Binding
-	ContextFilter   key.Binding
-	Add             key.Binding
-	Edit            key.Binding
-	Done            key.Binding
-	Undo            key.Binding
-	Inbox           key.Binding
-	Now             key.Binding
-	Waiting         key.Binding
-	Later           key.Binding
-	Delete          key.Binding
-	Esc             key.Binding
+	Quit          key.Binding
+	Help          key.Binding
+	NextView      key.Binding
+	PrevView      key.Binding
+	Refresh       key.Binding
+	Up            key.Binding
+	Down          key.Binding
+	Top           key.Binding
+	Bottom        key.Binding
+	DetailUp      key.Binding
+	DetailDown    key.Binding
+	Select        key.Binding
+	Search        key.Binding
+	ProjectFilter key.Binding
+	ContextFilter key.Binding
+	Add           key.Binding
+	Edit          key.Binding
+	Done          key.Binding
+	Undo          key.Binding
+	Inbox         key.Binding
+	Now           key.Binding
+	Waiting       key.Binding
+	Later         key.Binding
+	Delete        key.Binding
+	Esc           key.Binding
 }
 
 func defaultKeyMap() keyMap {
 	return keyMap{
-		Quit:            key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
-		Help:            key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-		NextView:        key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next view")),
-		PrevView:        key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev view")),
-		Refresh:         key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
-		Up:              key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/up", "move up")),
-		Down:            key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/down", "move down")),
-		Top:             key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
-		Bottom:          key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
-		Select:          key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "apply")),
-		CycleCompletion: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todo/all/done")),
-		Search:          key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
-		ProjectFilter:   key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "project filter")),
-		ContextFilter:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "context filter")),
-		Add:             key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
-		Edit:            key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
-		Done:            key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "done")),
-		Undo:            key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "undo")),
-		Inbox:           key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "inbox")),
-		Now:             key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "now")),
-		Waiting:         key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "waiting")),
-		Later:           key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "later")),
-		Delete:          key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "delete")),
-		Esc:             key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "clear")),
+		Quit:          key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+		Help:          key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		NextView:      key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next view")),
+		PrevView:      key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev view")),
+		Refresh:       key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+		Up:            key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/up", "move up")),
+		Down:          key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/down", "move down")),
+		Top:           key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
+		Bottom:        key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
+		DetailUp:      key.NewBinding(key.WithKeys("pgup", "ctrl+b"), key.WithHelp("pgup", "detail up")),
+		DetailDown:    key.NewBinding(key.WithKeys("pgdown", "ctrl+f"), key.WithHelp("pgdn", "detail down")),
+		Select:        key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "apply")),
+		Search:        key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
+		ProjectFilter: key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "project filter")),
+		ContextFilter: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "context filter")),
+		Add:           key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
+		Edit:          key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
+		Done:          key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "done")),
+		Undo:          key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "undo")),
+		Inbox:         key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "inbox")),
+		Now:           key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "now")),
+		Waiting:       key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "waiting")),
+		Later:         key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "later")),
+		Delete:        key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "delete")),
+		Esc:           key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "clear")),
+	}
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		k.Up,
+		k.Down,
+		k.Search,
+		k.Add,
+		k.Edit,
+		k.Done,
+		k.Undo,
+		k.Delete,
+		k.Help,
+		k.Quit,
+	}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Up, k.Down, k.Top, k.Bottom, k.DetailUp, k.DetailDown, k.NextView, k.PrevView, k.Search, k.Esc},
+		{k.ProjectFilter, k.ContextFilter, k.Add, k.Edit, k.Done, k.Undo, k.Inbox, k.Now, k.Waiting, k.Later, k.Delete},
+		{k.Refresh, k.Help, k.Quit},
 	}
 }

--- a/internal/tui/model_detail_test.go
+++ b/internal/tui/model_detail_test.go
@@ -1,0 +1,88 @@
+//nolint:testpackage // Tests validate internal detail viewport behavior directly.
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mholtzscher/ugh/internal/store"
+)
+
+func TestScrollDetailDownAndUp(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.tasks = []*store.Task{{
+		ID:    1,
+		State: store.StateNow,
+		Title: "scroll me",
+		Notes: strings.Repeat("line\n", 64),
+	}}
+	m.selected = 0
+	m.detail.Width = 40
+	m.detail.Height = 6
+	m.detail.SetContent(m.renderTaskDetailContent())
+
+	before := m.detail.YOffset
+	afterDownModel, _ := m.scrollDetailDown()
+	afterDown := afterDownModel.(model)
+	if afterDown.detail.YOffset <= before {
+		t.Fatalf("expected detail offset to increase, before=%d after=%d", before, afterDown.detail.YOffset)
+	}
+
+	afterUpModel, _ := afterDown.scrollDetailUp()
+	afterUp := afterUpModel.(model)
+	if afterUp.detail.YOffset >= afterDown.detail.YOffset {
+		t.Fatalf(
+			"expected detail offset to decrease, before=%d after=%d",
+			afterDown.detail.YOffset,
+			afterUp.detail.YOffset,
+		)
+	}
+}
+
+func TestScrollDetailNoSelectedTaskNoop(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.detail.Width = 40
+	m.detail.Height = 6
+	m.detail.SetContent("a\nb\nc\nd\ne\nf\ng")
+
+	before := m.detail.YOffset
+	updatedModel, _ := m.scrollDetailDown()
+	updated := updatedModel.(model)
+	if updated.detail.YOffset != before {
+		t.Fatalf("expected no offset change without selected task, before=%d after=%d", before, updated.detail.YOffset)
+	}
+}
+
+func TestMoveSelectionResetsDetailOffset(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.tasks = []*store.Task{
+		{ID: 1, State: store.StateNow, Title: "one", Notes: strings.Repeat("line\n", 64)},
+		{ID: 2, State: store.StateNow, Title: "two", Notes: strings.Repeat("line\n", 64)},
+	}
+	m.selected = 0
+	m.detail.Width = 40
+	m.detail.Height = 6
+	m.detail.SetContent(m.renderTaskDetailContent())
+	m.detail.HalfPageDown()
+
+	updatedModel, _ := m.moveCurrentSelection(1)
+	updated := updatedModel.(model)
+	if updated.detail.YOffset != 0 {
+		t.Fatalf("expected detail offset reset on selection change, got %d", updated.detail.YOffset)
+	}
+}
+
+func TestApplyTasksLoadedResetsDetailOffsetWhenSelectedTaskChanges(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.tasks = []*store.Task{{ID: 10, State: store.StateNow, Title: "old"}}
+	m.selected = 0
+	m.detail.Width = 40
+	m.detail.Height = 6
+	m.detail.SetContent(strings.Repeat("line\n", 64))
+	m.detail.HalfPageDown()
+
+	updated := m.applyTasksLoaded(tasksLoadedMsg{tasks: []*store.Task{{ID: 20, State: store.StateNow, Title: "new"}}})
+	if updated.detail.YOffset != 0 {
+		t.Fatalf("expected detail offset reset after task switch, got %d", updated.detail.YOffset)
+	}
+}

--- a/internal/tui/model_form_test.go
+++ b/internal/tui/model_form_test.go
@@ -1,0 +1,38 @@
+//nolint:testpackage // Tests validate internal form-key handling directly.
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTaskFormNotesEnterDoesNotAdvanceField(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.taskForm = startAddTaskForm(searchInputWidth).withField(taskFormFieldNotes)
+
+	updatedModel, _ := m.handleTaskFormInput(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, ok := updatedModel.(model)
+	if !ok {
+		t.Fatalf("unexpected model type %T", updatedModel)
+	}
+
+	if updated.taskForm.field != taskFormFieldNotes {
+		t.Fatalf("expected notes field to remain active, got %v", updated.taskForm.field)
+	}
+}
+
+func TestTaskFormNotesTabAdvancesField(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.taskForm = startAddTaskForm(searchInputWidth).withField(taskFormFieldNotes)
+
+	updatedModel, _ := m.handleTaskFormInput(tea.KeyMsg{Type: tea.KeyTab})
+	updated, ok := updatedModel.(model)
+	if !ok {
+		t.Fatalf("unexpected model type %T", updatedModel)
+	}
+
+	if updated.taskForm.field != taskFormFieldDue {
+		t.Fatalf("expected due field after tab, got %v", updated.taskForm.field)
+	}
+}

--- a/internal/tui/model_table_test.go
+++ b/internal/tui/model_table_test.go
@@ -1,0 +1,65 @@
+//nolint:testpackage // Tests validate internal table helpers directly.
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/table"
+
+	"github.com/mholtzscher/ugh/internal/store"
+)
+
+func TestTaskTableRowsMatchColumns(t *testing.T) {
+	tasks := []*store.Task{
+		{ID: 1, State: store.StateInbox, Title: "first"},
+		{ID: 2, State: store.StateDone, Title: "second"},
+	}
+
+	tests := []struct {
+		name      string
+		showState bool
+	}{
+		{name: "all tab includes state", showState: true},
+		{name: "state tab omits state", showState: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cols := taskTableColumns(tt.showState, 80)
+			rows := taskTableRows(tasks, tt.showState)
+			if len(rows) != len(tasks) {
+				t.Fatalf("expected %d rows, got %d", len(tasks), len(rows))
+			}
+			for i, row := range rows {
+				if len(row) != len(cols) {
+					t.Fatalf("row %d has %d cells, want %d", i, len(row), len(cols))
+				}
+			}
+		})
+	}
+}
+
+func TestSetTaskTableDataHandlesColumnCountChange(t *testing.T) {
+	taskTable := table.New()
+
+	setTaskTableData(
+		&taskTable,
+		taskTableColumns(true, 80),
+		taskTableRows([]*store.Task{{ID: 1, State: store.StateInbox, Title: "first"}}, true),
+		0,
+	)
+
+	setTaskTableData(
+		&taskTable,
+		taskTableColumns(false, 80),
+		taskTableRows([]*store.Task{{ID: 1, State: store.StateInbox, Title: "first"}}, false),
+		0,
+	)
+
+	if got := len(taskTable.Columns()); got != 3 {
+		t.Fatalf("expected 3 columns after switch, got %d", got)
+	}
+	if got := len(taskTable.Rows()); got != 1 {
+		t.Fatalf("expected 1 row after switch, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- split monolithic TUI rendering helpers into dedicated shell, list, and form component files to simplify model responsibilities
- switch task list/detail panes to Bubble components (`table`, `viewport`, `help`, and `spinner`) for cleaner layout sizing, scrolling, and loading feedback
- improve task form behavior with multiline notes input and tab/enter handling, and add targeted tests for table, form, and detail interactions

## Validation
- just check