### PR TITLE
feat(shell): rename context commands from 'set' to 'context' syntax

### DIFF
--- a/docs/shell-and-dsl.md
+++ b/docs/shell-and-dsl.md
@@ -75,7 +75,7 @@ flowchart LR
 **Features:**
 - **Three modes**: Interactive REPL, script file execution, stdin pipe
 - **Pronoun resolution**: `it`/`this` → last task, `that` → second-to-last, `selected` → selected task
-- **Sticky context**: `set #project` and `set @context` apply to all subsequent commands
+- **Sticky context**: `context #project` and `context @context` apply to all subsequent commands
 - **Session persistence**: Tracks recently accessed tasks and selected task
 
 ### 2. NLP Layer (`internal/nlp/`)
@@ -245,8 +245,8 @@ flowchart LR
 ```mermaid
 flowchart LR
     subgraph Context["Sticky Context Set"]
-        C1["set #work"]
-        C2["set @urgent"]
+        C1["context #work"]
+        C2["context @urgent"]
     end
 
     A["list state:now"] --> B["Context Injection:<br/>#work + @urgent"]
@@ -291,9 +291,9 @@ show id:123
 ### Context Commands
 
 ```
-set #project        # Set default project filter
-set @context        # Set default context filter
-clear context       # Remove all sticky filters
+context #project    # Set default project filter
+context @context    # Set default context filter
+context clear       # Remove all sticky filters
 ```
 
 ## Key Design Decisions

--- a/internal/shell/repl.go
+++ b/internal/shell/repl.go
@@ -177,7 +177,7 @@ func (r *REPL) processCommand(ctx context.Context, input string) error {
 		return nil
 	}
 
-	// Handle context commands: set #project, set @context, clear context
+	// Handle context commands: context #project, context @context, context clear
 	if result, handled := r.handleContextCommand(cmd); handled {
 		r.display.ShowResult(result)
 		return nil
@@ -241,12 +241,12 @@ func (r *REPL) showHelp() {
 	_, _ = fmt.Fprintln(os.Stdout, "    #123              Task ID")
 	_, _ = fmt.Fprintln(os.Stdout, "")
 	_, _ = fmt.Fprintln(os.Stdout, "  Context (sticky filters):")
-	_, _ = fmt.Fprintln(os.Stdout, "    set #project      Set default project context")
-	_, _ = fmt.Fprintln(os.Stdout, "    set @context      Set default context filter")
-	_, _ = fmt.Fprintln(os.Stdout, "    clear context     Clear all context filters")
+	_, _ = fmt.Fprintln(os.Stdout, "    context #project  Set default project context")
+	_, _ = fmt.Fprintln(os.Stdout, "    context @context  Set default context filter")
+	_, _ = fmt.Fprintln(os.Stdout, "    context clear     Clear all context filters")
 }
 
-// handleContextCommand handles context setting commands like "set #work" or "set @home".
+// handleContextCommand handles context setting commands like "context #work" or "context @home".
 // Returns (result, true) if handled, (nil, false) otherwise.
 func (r *REPL) handleContextCommand(cmd string) (*ExecuteResult, bool) {
 	const contextCommandParts = 2
@@ -255,8 +255,8 @@ func (r *REPL) handleContextCommand(cmd string) (*ExecuteResult, bool) {
 		return nil, false
 	}
 
-	// Handle "clear context" command
-	if parts[0] == "clear" && parts[1] == "context" {
+	// Handle "context clear" command
+	if parts[0] == "context" && parts[1] == "clear" {
 		r.state.ContextProject = ""
 		r.state.ContextContext = ""
 		return &ExecuteResult{
@@ -267,8 +267,8 @@ func (r *REPL) handleContextCommand(cmd string) (*ExecuteResult, bool) {
 		}, true
 	}
 
-	// Handle "set #project" or "set @context"
-	if parts[0] == "set" {
+	// Handle "context #project" or "context @context"
+	if parts[0] == "context" {
 		token := parts[1]
 		if strings.HasPrefix(token, "#") && len(token) > 1 {
 			r.state.ContextProject = strings.TrimPrefix(token, "#")


### PR DESCRIPTION
## Summary
Renames shell context commands from `set`/`clear` syntax to unified `context` syntax to resolve collision with NLP update commands.

## Changes
- Changed `set #project` → `context #project`
- Changed `set @context` → `context @context`  
- Changed `clear context` → `context clear`
- Updated help text and documentation

## Problem Solved
`set #work` was intercepted by the REPL as a sticky context command, but the NLP parser legitimately parses `set #work` as an update command (add project tag to selected task). The same input had different semantics depending on execution path.

## New Syntax
```
context #work       # Set project context
context @urgent     # Set context filter
context clear       # Clear all context filters
```

Closes #18