### PR TITLE
feat(shell): add color output support with pterm integration

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -38,6 +38,7 @@ var shellCmd = &cli.Command{
 		}
 
 		var opts shell.Options
+		opts.NoColor = rootNoColor
 
 		if cmd.String("file") != "" {
 			opts.Mode = shell.ModeScriptFile

--- a/internal/shell/display.go
+++ b/internal/shell/display.go
@@ -3,14 +3,18 @@ package shell
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/pterm/pterm"
 
 	"github.com/mholtzscher/ugh/internal/output"
 )
 
 // Display handles output formatting.
 type Display struct {
-	mode   DisplayMode
-	writer output.Writer
+	mode    DisplayMode
+	writer  output.Writer
+	noColor bool
 }
 
 // DisplayMode defines how to display results.
@@ -23,10 +27,11 @@ const (
 )
 
 // NewDisplay creates a new display handler.
-func NewDisplay() *Display {
+func NewDisplay(noColor bool) *Display {
 	return &Display{
-		mode:   DisplayCompact,
-		writer: output.NewWriter(false, false),
+		mode:    DisplayCompact,
+		writer:  output.NewWriter(false, noColor),
+		noColor: noColor,
 	}
 }
 
@@ -47,7 +52,36 @@ func (d *Display) ShowResult(result *ExecuteResult) {
 }
 
 func (d *Display) showCompact(result *ExecuteResult) {
-	if result.Message != "" {
+	if result.Message == "" {
+		return
+	}
+
+	if d.noColor {
+		_ = d.writer.WriteLine(result.Message)
+		return
+	}
+
+	// Map intents to appropriate pterm styles
+	intent := strings.ToLower(result.Intent)
+	switch {
+	case strings.Contains(intent, "add"), strings.Contains(intent, "create"), strings.Contains(intent, "new"):
+		_ = pterm.Success.Println(result.Message)
+	case strings.Contains(intent, "done"), strings.Contains(intent, "complete"):
+		_ = pterm.Success.Println(result.Message)
+	case strings.Contains(intent, "undo"), strings.Contains(intent, "revert"):
+		_ = pterm.Success.Println(result.Message)
+	case strings.Contains(intent, "delete"), strings.Contains(intent, "rm"), strings.Contains(intent, "remove"):
+		_ = pterm.Warning.Println(result.Message)
+	case strings.Contains(intent, "error"), strings.Contains(intent, "fail"):
+		_ = pterm.Error.Println(result.Message)
+	case strings.Contains(intent, "show"),
+		strings.Contains(intent, "list"),
+		strings.Contains(intent, "find"),
+		strings.Contains(intent, "filter"):
+		_ = d.writer.WriteLine(result.Message)
+	case strings.Contains(intent, "context"), strings.Contains(intent, "help"):
+		_ = d.writer.WriteLine(result.Message)
+	default:
 		_ = d.writer.WriteLine(result.Message)
 	}
 }

--- a/internal/shell/prompt.go
+++ b/internal/shell/prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/chzyer/readline"
+	"github.com/pterm/pterm"
 
 	"github.com/mholtzscher/ugh/internal/service"
 )
@@ -15,9 +16,14 @@ type Prompt struct {
 }
 
 // NewPrompt creates a new interactive prompt with history loaded from SQLite.
-func NewPrompt(svc service.Service) (*Prompt, error) {
+func NewPrompt(svc service.Service, noColor bool) (*Prompt, error) {
+	promptText := "ugh> "
+	if !noColor {
+		promptText = pterm.Cyan("➜ ") + pterm.Magenta("ugh> ")
+	}
+
 	cfg := &readline.Config{
-		Prompt:          "ugh> ",
+		Prompt:          promptText,
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",
 	}


### PR DESCRIPTION
## Summary

Add --no-color flag support to the interactive shell (REPL) for controlling output styling using the pterm library.

## Changes

- **cmd/shell.go**: Wire rootNoColor to shell options
- **shell/display.go**: Add noColor field with intent-based message styling (success, warning, error)
- **shell/executor.go**: Colored task formatting functions (cyan IDs, magenta states, blue projects, green contexts, yellow due dates)
- **shell/prompt.go**: Conditional colored prompt text (cyan arrow + magenta prompt)
- **shell/repl.go**: NoColor in Options, colored help display with syntax highlighting

## Features

When colors are enabled (default), the shell now provides:
- Styled prompts with visual indicators
- Intent-based message styling that maps command types to appropriate colors
- Syntax-highlighted help with color-coded command categories
- Big text banner on startup

The no-color mode uses plain text output for terminals without color support or when piping output.