### PR TITLE
refactor(store): use squirrel for filter query generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/Masterminds/squirrel v1.5.4
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/chzyer/readline v1.5.1
 	github.com/pressly/goose/v3 v3.26.0
@@ -23,6 +24,8 @@ require (
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/gookit/color v1.5.4 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi+zB4=
 github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc4n3EjyIYvEY=
+github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
+github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
@@ -60,6 +62,10 @@ github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
 github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -94,6 +100,7 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -13,6 +13,9 @@ schema = 3
   [mod."github.com/BurntSushi/toml"]
     version = "v1.6.0"
     hash = "sha256-ptdUJvuc21ixeLt+M5way/na3aCnCO4MYHWulWp8NEY="
+  [mod."github.com/Masterminds/squirrel"]
+    version = "v1.5.4"
+    hash = "sha256-7UGz8TLcBI9HjU7zPqj9Gjp9Av+43mu0YCBV1mRy34o="
   [mod."github.com/alecthomas/participle/v2"]
     version = "v2.1.4"
     hash = "sha256-MNNIJGTV6Rqm5rEPQX0Nro0XTzJ9/SmQ24hZ4kJaiIM="
@@ -34,6 +37,12 @@ schema = 3
   [mod."github.com/gookit/color"]
     version = "v1.5.4"
     hash = "sha256-6Xydefyslup+qohzatAdezGWrS065X5mx18wvRef3Rk="
+  [mod."github.com/lann/builder"]
+    version = "v0.0.0-20180802200727-47ae307949d0"
+    hash = "sha256-NDZvsU6T2jVq5pfhp/VoJcMTq8DXKXiEkfZHloOX6c0="
+  [mod."github.com/lann/ps"]
+    version = "v0.0.0-20150810152359-62de8c46ede0"
+    hash = "sha256-fHIjAtshTJWa67PzzgruqN1LdpQ7Zgc1qpEZWhjQTnU="
   [mod."github.com/lithammer/fuzzysearch"]
     version = "v1.1.8"
     hash = "sha256-aMMRcrlUc9CBiiNkcnWWn4hfNMNyVhrAt67kvP4D4Do="

--- a/internal/store/filter_sql_builder.go
+++ b/internal/store/filter_sql_builder.go
@@ -5,117 +5,116 @@ import (
 	"strconv"
 	"strings"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/mholtzscher/ugh/internal/nlp"
 )
 
-type filterSQLBuilder struct {
-	args []any
-}
+type filterSQLBuilder struct{}
 
 func (b *filterSQLBuilder) Build(expr nlp.FilterExpr) (string, []any, error) {
-	clause, err := b.buildExpr(expr)
+	sqlizer, err := b.buildExpr(expr)
 	if err != nil {
 		return "", nil, err
 	}
-	return clause, b.args, nil
+
+	clause, args, err := sqlizer.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	return clause, args, nil
 }
 
-func (b *filterSQLBuilder) buildExpr(expr nlp.FilterExpr) (string, error) {
+func (b *filterSQLBuilder) buildExpr(expr nlp.FilterExpr) (sq.Sqlizer, error) {
 	switch typed := expr.(type) {
 	case nlp.Predicate:
 		return b.buildPredicate(typed)
 	case nlp.FilterBinary:
 		left, err := b.buildExpr(typed.Left)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		right, err := b.buildExpr(typed.Right)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		op := "AND"
 		if typed.Op == nlp.FilterOr {
-			op = "OR"
+			return sq.Or{left, right}, nil
 		}
-		return fmt.Sprintf("(%s %s %s)", left, op, right), nil
+		return sq.And{left, right}, nil
 	case nlp.FilterNot:
 		inner, err := b.buildExpr(typed.Expr)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return fmt.Sprintf("(NOT %s)", inner), nil
+		return sq.Expr("(NOT (?))", inner), nil
 	default:
-		return "", fmt.Errorf("unsupported filter expression type %T", expr)
+		return nil, fmt.Errorf("unsupported filter expression type %T", expr)
 	}
 }
 
-func (b *filterSQLBuilder) buildPredicate(pred nlp.Predicate) (string, error) {
+func (b *filterSQLBuilder) buildPredicate(pred nlp.Predicate) (sq.Sqlizer, error) {
 	value := strings.TrimSpace(pred.Text)
 
 	switch pred.Kind {
 	case nlp.PredState:
-		b.args = append(b.args, value)
-		return "(t.state = ?)", nil
+		return sq.Eq{"t.state": value}, nil
 	case nlp.PredDue:
 		if value == "" {
-			return "(t.due_on IS NOT NULL AND t.due_on != '')", nil
+			return sq.Expr("(t.due_on IS NOT NULL AND t.due_on != '')"), nil
 		}
-		b.args = append(b.args, value)
-		return "(t.due_on = ?)", nil
+		return sq.Eq{"t.due_on": value}, nil
 	case nlp.PredProject:
-		b.args = append(b.args, value)
-		return `EXISTS (
-			SELECT 1
-			FROM task_project_links tpl
-			JOIN projects p ON p.id = tpl.project_id
-			WHERE tpl.task_id = t.id AND p.name = ?
-		)`, nil
+		subquery := sq.Select("1").
+			From("task_project_links tpl").
+			Join("projects p ON p.id = tpl.project_id").
+			Where(sq.Expr("tpl.task_id = t.id")).
+			Where(sq.Eq{"p.name": value})
+		return sq.Expr("EXISTS (?)", subquery), nil
 	case nlp.PredContext:
-		b.args = append(b.args, value)
-		return `EXISTS (
-			SELECT 1
-			FROM task_context_links tcl
-			JOIN contexts c ON c.id = tcl.context_id
-			WHERE tcl.task_id = t.id AND c.name = ?
-		)`, nil
+		subquery := sq.Select("1").
+			From("task_context_links tcl").
+			Join("contexts c ON c.id = tcl.context_id").
+			Where(sq.Expr("tcl.task_id = t.id")).
+			Where(sq.Eq{"c.name": value})
+		return sq.Expr("EXISTS (?)", subquery), nil
 	case nlp.PredText:
 		if value == "" {
-			return "1=1", nil
+			return sq.Expr("1=1"), nil
 		}
 		like := "%" + value + "%"
-		b.args = append(b.args, like, like, like, like, like, like)
-		return `(
-			t.title LIKE ?
-			OR t.notes LIKE ?
-			OR EXISTS (
-				SELECT 1
-				FROM task_project_links tpl
-				JOIN projects p ON p.id = tpl.project_id
-				WHERE tpl.task_id = t.id AND p.name LIKE ?
-			)
-			OR EXISTS (
-				SELECT 1
-				FROM task_context_links tcl
-				JOIN contexts c ON c.id = tcl.context_id
-				WHERE tcl.task_id = t.id AND c.name LIKE ?
-			)
-			OR EXISTS (
-				SELECT 1
-				FROM task_meta m
-				WHERE m.task_id = t.id AND (
-					m.key LIKE ?
-					OR m.value LIKE ?
-				)
-			)
-		)`, nil
+
+		projectSubquery := sq.Select("1").
+			From("task_project_links tpl").
+			Join("projects p ON p.id = tpl.project_id").
+			Where(sq.Expr("tpl.task_id = t.id")).
+			Where(sq.Like{"p.name": like})
+
+		contextSubquery := sq.Select("1").
+			From("task_context_links tcl").
+			Join("contexts c ON c.id = tcl.context_id").
+			Where(sq.Expr("tcl.task_id = t.id")).
+			Where(sq.Like{"c.name": like})
+
+		metaSubquery := sq.Select("1").
+			From("task_meta m").
+			Where(sq.Expr("m.task_id = t.id")).
+			Where(sq.Or{sq.Like{"m.key": like}, sq.Like{"m.value": like}})
+
+		return sq.Or{
+			sq.Like{"t.title": like},
+			sq.Like{"t.notes": like},
+			sq.Expr("EXISTS (?)", projectSubquery),
+			sq.Expr("EXISTS (?)", contextSubquery),
+			sq.Expr("EXISTS (?)", metaSubquery),
+		}, nil
 	case nlp.PredID:
 		id, err := strconv.ParseInt(value, 10, 64)
 		if err != nil || id <= 0 {
-			return "", fmt.Errorf("invalid id predicate %q", pred.Text)
+			return nil, fmt.Errorf("invalid id predicate %q", pred.Text)
 		}
-		b.args = append(b.args, id)
-		return "(t.id = ?)", nil
+		return sq.Eq{"t.id": id}, nil
 	default:
-		return "", fmt.Errorf("unsupported predicate kind %v", pred.Kind)
+		return nil, fmt.Errorf("unsupported predicate kind %v", pred.Kind)
 	}
 }

--- a/internal/store/filter_sql_builder_test.go
+++ b/internal/store/filter_sql_builder_test.go
@@ -77,3 +77,54 @@ func TestFilterSQLBuilder_InvalidIDReturnsError(t *testing.T) {
 		t.Fatal("Build() error = nil, want invalid id error")
 	}
 }
+
+func TestFilterSQLBuilder_EmptyDuePredicateHasNoArgs(t *testing.T) {
+	t.Parallel()
+
+	b := &filterSQLBuilder{}
+	clause, args, err := b.Build(nlp.Predicate{Kind: nlp.PredDue, Text: ""})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if !strings.Contains(clause, "t.due_on IS NOT NULL") {
+		t.Fatalf("clause = %q, want IS NOT NULL", clause)
+	}
+	if !strings.Contains(clause, "t.due_on != ''") {
+		t.Fatalf("clause = %q, want non-empty due check", clause)
+	}
+	if len(args) != 0 {
+		t.Fatalf("args len = %d, want 0", len(args))
+	}
+}
+
+func TestFilterSQLBuilder_NotWrapsNestedOrExpression(t *testing.T) {
+	t.Parallel()
+
+	b := &filterSQLBuilder{}
+	expr := nlp.FilterNot{
+		Expr: nlp.FilterBinary{
+			Op:    nlp.FilterOr,
+			Left:  nlp.Predicate{Kind: nlp.PredState, Text: "now"},
+			Right: nlp.Predicate{Kind: nlp.PredState, Text: "waiting"},
+		},
+	}
+
+	clause, args, err := b.Build(expr)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if !strings.Contains(clause, "NOT") {
+		t.Fatalf("clause = %q, want NOT", clause)
+	}
+	if !strings.Contains(clause, "t.state = ? OR t.state = ?") {
+		t.Fatalf("clause = %q, want nested OR", clause)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args len = %d, want 2", len(args))
+	}
+	if args[0] != "now" || args[1] != "waiting" {
+		t.Fatalf("args = %#v, want [now waiting]", args)
+	}
+}

--- a/internal/store/store_filter_test.go
+++ b/internal/store/store_filter_test.go
@@ -4,7 +4,9 @@ package store
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/mholtzscher/ugh/internal/nlp"
 )
@@ -49,6 +51,88 @@ func TestListTasksByExpr_BooleanSemantics(t *testing.T) {
 	if len(tasks) != 2 {
 		t.Fatalf("ListTasksByExpr(not) count = %d, want 2", len(tasks))
 	}
+}
+
+func TestListTasksByExpr_NestedBooleanFilterIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	nowWorkDue := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+	nowWork, err := s.CreateTask(ctx, &Task{
+		Title:    "Now Work",
+		State:    StateNow,
+		Projects: []string{"work"},
+		DueOn:    &nowWorkDue,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(now work) error = %v", err)
+	}
+
+	waitingHomeDue := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	_, err = s.CreateTask(ctx, &Task{
+		Title:    "Waiting Home",
+		State:    StateWaiting,
+		Projects: []string{"home"},
+		DueOn:    &waitingHomeDue,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(waiting home) error = %v", err)
+	}
+
+	waitingWorkDue := time.Date(2026, time.January, 3, 0, 0, 0, 0, time.UTC)
+	waitingWork, err := s.CreateTask(ctx, &Task{
+		Title:    "Waiting Work",
+		State:    StateWaiting,
+		Projects: []string{"work"},
+		DueOn:    &waitingWorkDue,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(waiting work) error = %v", err)
+	}
+
+	laterWorkDue := time.Date(2026, time.January, 4, 0, 0, 0, 0, time.UTC)
+	_, err = s.CreateTask(ctx, &Task{
+		Title:    "Later Work",
+		State:    StateLater,
+		Projects: []string{"work"},
+		DueOn:    &laterWorkDue,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(later work) error = %v", err)
+	}
+
+	filter := nlp.FilterBinary{
+		Op: nlp.FilterAnd,
+		Left: nlp.FilterBinary{
+			Op:    nlp.FilterOr,
+			Left:  nlp.Predicate{Kind: nlp.PredState, Text: "now"},
+			Right: nlp.Predicate{Kind: nlp.PredState, Text: "waiting"},
+		},
+		Right: nlp.FilterNot{
+			Expr: nlp.Predicate{Kind: nlp.PredProject, Text: "home"},
+		},
+	}
+
+	tasks, err := s.ListTasksByExpr(ctx, filter, ListTasksByExprOptions{ExcludeDone: true})
+	if err != nil {
+		t.Fatalf("ListTasksByExpr(nested) error = %v", err)
+	}
+
+	gotIDs := taskIDs(tasks)
+	wantIDs := []int64{nowWork.ID, waitingWork.ID}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("ListTasksByExpr(nested) ids = %v, want %v", gotIDs, wantIDs)
+	}
+}
+
+func taskIDs(tasks []*Task) []int64 {
+	ids := make([]int64, 0, len(tasks))
+	for _, task := range tasks {
+		ids = append(ids, task.ID)
+	}
+	return ids
 }
 
 func openTestStore(t *testing.T) *Store {


### PR DESCRIPTION
## Summary
- Replace manual SQL string/arg assembly in store filtering with Squirrel SQL builders.
- Refactor filter expression compilation to produce `sq.Sqlizer` values and delegate argument binding to `ToSql`.
- Add coverage for empty due predicates and nested boolean filter behavior to ensure query semantics remain correct.