### PR TITLE
refactor(nlp): map tag prefix stripping at parse time

### DIFF
--- a/internal/nlp/dsl_nodes.go
+++ b/internal/nlp/dsl_nodes.go
@@ -27,13 +27,13 @@ func (t *tagOpNode) Parse(lex *lexer.PeekingLexer) error {
 	if tok.Type == dslSymbols["ProjectTag"] {
 		lex.Next()
 		t.Kind = TagProject
-		t.Value = strings.TrimPrefix(tok.Value, "#")
+		t.Value = tok.Value
 		return nil
 	}
 	if tok.Type == dslSymbols["ContextTag"] {
 		lex.Next()
 		t.Kind = TagContext
-		t.Value = strings.TrimPrefix(tok.Value, "@")
+		t.Value = tok.Value
 		return nil
 	}
 	return participle.NextMatch

--- a/internal/nlp/dsl_parser.go
+++ b/internal/nlp/dsl_parser.go
@@ -1,7 +1,10 @@
 package nlp
 
 import (
+	"strings"
+
 	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
 )
 
 //nolint:gochecknoglobals // Parser is a package-level singleton for participle.
@@ -9,6 +12,8 @@ var dslParser = participle.MustBuild[Root](
 	participle.Lexer(dslLexer),
 	participle.Elide("Whitespace"),
 	participle.Unquote("Quoted"),
+	participle.Map(trimPrefixTokenMapper("#"), "ProjectTag"),
+	participle.Map(trimPrefixTokenMapper("@"), "ContextTag"),
 	participle.Union[Command](
 		&CreateCommand{},
 		&UpdateCommand{},
@@ -34,3 +39,10 @@ var dslParser = participle.MustBuild[Root](
 		&dueShorthandNode{},
 	),
 )
+
+func trimPrefixTokenMapper(prefix string) func(lexer.Token) (lexer.Token, error) {
+	return func(tok lexer.Token) (lexer.Token, error) {
+		tok.Value = strings.TrimPrefix(tok.Value, prefix)
+		return tok, nil
+	}
+}

--- a/internal/nlp/dsl_postprocess.go
+++ b/internal/nlp/dsl_postprocess.go
@@ -209,10 +209,10 @@ func (p *FilterTagPredicate) toPredicate() *Predicate {
 		return nil
 	}
 	if p.Project != "" {
-		return &Predicate{Kind: PredProject, Text: strings.TrimPrefix(p.Project, "#")}
+		return &Predicate{Kind: PredProject, Text: p.Project}
 	}
 	if p.Context != "" {
-		return &Predicate{Kind: PredContext, Text: strings.TrimPrefix(p.Context, "@")}
+		return &Predicate{Kind: PredContext, Text: p.Context}
 	}
 	return &Predicate{Kind: PredText, Text: ""}
 }

--- a/internal/nlp/parser_test.go
+++ b/internal/nlp/parser_test.go
@@ -798,6 +798,18 @@ func TestParseFilter_Predicates(t *testing.T) {
 			wantText: "phone",
 		},
 		{
+			name:     "project tag shorthand predicate",
+			input:    "find #work",
+			wantKind: nlp.PredProject,
+			wantText: "work",
+		},
+		{
+			name:     "context tag shorthand predicate",
+			input:    "find @phone",
+			wantKind: nlp.PredContext,
+			wantText: "phone",
+		},
+		{
 			name:     "text predicate",
 			input:    "find text:report",
 			wantKind: nlp.PredText,


### PR DESCRIPTION
## Summary
- map `ProjectTag` and `ContextTag` tokens with `participle.Map` so `#` and `@` prefixes are stripped during parser token normalization
- remove redundant prefix stripping from `tagOpNode.Parse` and `FilterTagPredicate.toPredicate`
- add parser coverage for shorthand filter tags (`find #work`, `find @phone`) to confirm normalized predicate values

## Validation
- `just check`

Closes #37