### PR TITLE
refactor(nlp): use case-insensitive lexer token instead of manual lowercasing

### DIFF
--- a/cmd/filter_expr.go
+++ b/cmd/filter_expr.go
@@ -77,7 +77,7 @@ func andExpr(exprs ...nlp.FilterExpr) nlp.FilterExpr {
 }
 
 func stateExpr(value string) nlp.FilterExpr {
-	value = strings.TrimSpace(value)
+	value = strings.ToLower(strings.TrimSpace(value))
 	if value == "" {
 		return nil
 	}

--- a/internal/nlp/dsl_parse.go
+++ b/internal/nlp/dsl_parse.go
@@ -252,8 +252,8 @@ func isFilterValueDelimiter(tok *lexer.Token) bool {
 		return true
 	}
 	if tok.Type == dslSymbols["Ident"] {
-		lower := strings.ToLower(tok.Value)
-		return lower == "and" || lower == "or" || lower == "not"
+		s := strings.ToLower(tok.Value)
+		return s == "and" || s == "or" || s == "not"
 	}
 	return false
 }

--- a/internal/nlp/dsl_parser.go
+++ b/internal/nlp/dsl_parser.go
@@ -12,6 +12,7 @@ var dslParser = participle.MustBuild[Root](
 	participle.Lexer(dslLexer),
 	participle.Elide("Whitespace"),
 	participle.Unquote("Quoted"),
+	participle.CaseInsensitive("Ident"),
 	participle.Map(trimPrefixTokenMapper("#"), "ProjectTag"),
 	participle.Map(trimPrefixTokenMapper("@"), "ContextTag"),
 	participle.Union[Command](


### PR DESCRIPTION
Closes #36

Centralizes case-insensitive token handling by using participle.CaseInsensitive() in the parser configuration rather than manually calling strings.ToLower() throughout the DSL parsing code.