### PR TITLE
refactor(nlp): remove implicit due-date shorthand parsing

### DIFF
--- a/internal/nlp/ast.go
+++ b/internal/nlp/ast.go
@@ -195,15 +195,6 @@ type TagOp struct {
 func (TagOp) operation() {}
 func (TagOp) createOp()  {}
 
-// DueShorthandOp is a create-only shorthand for setting due date.
-// It is parsed from tokens like "today", "tomorrow", "next-week".
-type DueShorthandOp struct {
-	Value string
-}
-
-func (DueShorthandOp) operation() {}
-func (DueShorthandOp) createOp()  {}
-
 type FilterExpr interface {
 	filterExpr()
 }

--- a/internal/nlp/compile/plan.go
+++ b/internal/nlp/compile/plan.go
@@ -83,11 +83,6 @@ func buildCreateRequest(cmd *nlp.CreateCommand, opts BuildOptions) (service.Crea
 			}
 		case nlp.TagOp:
 			applyTag(&req, typed)
-		case nlp.DueShorthandOp:
-			dueSet := nlp.SetOp{Field: nlp.FieldDue, Value: nlp.OpValue(typed.Value)}
-			if err := applyCreateSet(&req, dueSet, opts.Now); err != nil {
-				return service.CreateTaskRequest{}, err
-			}
 		default:
 			return service.CreateTaskRequest{}, fmt.Errorf("unsupported create op type %T", op)
 		}

--- a/internal/nlp/compile/plan_test.go
+++ b/internal/nlp/compile/plan_test.go
@@ -11,7 +11,7 @@ import (
 func TestBuildCreatePlan(t *testing.T) {
 	t.Parallel()
 
-	parsed, err := nlp.Parse(`add buy milk tomorrow #home @errands waiting:alex`, nlp.ParseOptions{
+	parsed, err := nlp.Parse(`add buy milk due:tomorrow #home @errands waiting:alex`, nlp.ParseOptions{
 		Now: time.Date(2026, 2, 8, 10, 0, 0, 0, time.UTC),
 	})
 	if err != nil {

--- a/internal/nlp/dsl_nodes.go
+++ b/internal/nlp/dsl_nodes.go
@@ -2,7 +2,6 @@ package nlp
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
@@ -37,33 +36,4 @@ func (t *tagOpNode) Parse(lex *lexer.PeekingLexer) error {
 		return nil
 	}
 	return participle.NextMatch
-}
-
-type dueShorthandNode struct {
-	Value string
-}
-
-func (*dueShorthandNode) operation() {}
-func (*dueShorthandNode) createOp()  {}
-
-func (d *dueShorthandNode) Parse(lex *lexer.PeekingLexer) error {
-	if d == nil {
-		return errors.New("nil dueShorthandNode")
-	}
-	tok := lex.Peek()
-	if tok == nil {
-		return participle.NextMatch
-	}
-	if tok.Type != dslSymbols["Ident"] {
-		return participle.NextMatch
-	}
-	s := strings.ToLower(strings.TrimSpace(tok.Value))
-	switch s {
-	case "today", "tomorrow", "next-week":
-		lex.Next()
-		d.Value = s
-		return nil
-	default:
-		return participle.NextMatch
-	}
 }

--- a/internal/nlp/dsl_parser.go
+++ b/internal/nlp/dsl_parser.go
@@ -37,7 +37,6 @@ var dslParser = participle.MustBuild[Root](
 		&RemoveOp{},
 		&ClearOp{},
 		&tagOpNode{},
-		&dueShorthandNode{},
 	),
 )
 

--- a/internal/nlp/dsl_postprocess.go
+++ b/internal/nlp/dsl_postprocess.go
@@ -298,23 +298,11 @@ func normalizeOperation(op Operation) (Operation, bool) {
 			return nil, false
 		}
 		return TagOp{Kind: typed.Kind, Value: typed.Value}, true
-	case DueShorthandOp:
-		return typed, true
-	case *DueShorthandOp:
-		if typed == nil {
-			return nil, false
-		}
-		return DueShorthandOp{Value: typed.Value}, true
 	case *tagOpNode:
 		if typed == nil {
 			return nil, false
 		}
 		return TagOp{Kind: typed.Kind, Value: typed.Value}, true
-	case *dueShorthandNode:
-		if typed == nil {
-			return nil, false
-		}
-		return DueShorthandOp{Value: typed.Value}, true
 	default:
 		return op, true
 	}

--- a/internal/nlp/parser_test.go
+++ b/internal/nlp/parser_test.go
@@ -412,9 +412,9 @@ func TestParseCreate_Complex(t *testing.T) {
 
 	now := time.Date(2026, 2, 8, 10, 0, 0, 0, time.UTC)
 
-	// Complex combined create command
+	// Complex combined create command with explicit due date syntax
 	result, err := nlp.Parse(
-		"add buy milk tomorrow #groceries @store waiting:alex notes:organic preferred",
+		"add buy milk due:tomorrow #groceries @store waiting:alex notes:organic preferred",
 		nlp.ParseOptions{Now: now},
 	)
 	if err != nil {
@@ -1071,7 +1071,7 @@ func TestParseCreateCommand(t *testing.T) {
 	t.Parallel()
 
 	result, err := nlp.Parse(
-		`add buy milk tomorrow #home @errands waiting:alex`,
+		`add buy milk due:tomorrow #home @errands waiting:alex`,
 		nlp.ParseOptions{Now: time.Date(2026, 2, 8, 10, 0, 0, 0, time.UTC)},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- remove the create-only due shorthand operation (`today`, `tomorrow`, `next-week`) from the NLP DSL AST and parser pipeline
- simplify create-plan compilation by relying on explicit `due:<value>` field parsing rather than implicit identifier matching
- update parser and planner tests to use explicit due syntax (for example, `due:tomorrow`)

## Validation
- ran `just check` successfully

Closes #28