### PR TITLE
test(shell): add comprehensive tests for display, scripting, and executor

### DIFF
--- a/internal/shell/display_test.go
+++ b/internal/shell/display_test.go
@@ -1,0 +1,170 @@
+package shell_test
+
+import (
+	"testing"
+
+	"github.com/mholtzscher/ugh/internal/shell"
+)
+
+func TestNewDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		noColor bool
+	}{
+		{
+			name:    "with color",
+			noColor: false,
+		},
+		{
+			name:    "no color",
+			noColor: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			display := shell.NewDisplay(tt.noColor)
+			if display == nil {
+				t.Fatal("NewDisplay returned nil")
+			}
+		})
+	}
+}
+
+func TestDisplayShowResultNil(t *testing.T) {
+	t.Parallel()
+
+	display := shell.NewDisplay(true)
+
+	// Should not panic when result is nil
+	display.ShowResult(nil)
+}
+
+func TestDisplayShowResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		result  *shell.ExecuteResult
+		noColor bool
+	}{
+		{
+			name: "create intent",
+			result: &shell.ExecuteResult{
+				Intent:  "create",
+				Message: "Created task #1",
+			},
+			noColor: true,
+		},
+		{
+			name: "update intent",
+			result: &shell.ExecuteResult{
+				Intent:  "update",
+				Message: "Updated task #1",
+			},
+			noColor: true,
+		},
+		{
+			name: "filter intent",
+			result: &shell.ExecuteResult{
+				Intent:  "filter",
+				Message: "Found 5 tasks",
+			},
+			noColor: true,
+		},
+		{
+			name: "context intent",
+			result: &shell.ExecuteResult{
+				Intent:  "context",
+				Message: "Current context: #work",
+			},
+			noColor: true,
+		},
+		{
+			name: "help intent",
+			result: &shell.ExecuteResult{
+				Intent:  "help",
+				Message: "Available commands...",
+			},
+			noColor: true,
+		},
+		{
+			name: "done intent",
+			result: &shell.ExecuteResult{
+				Intent:  "done",
+				Message: "Marked 3 tasks as done",
+			},
+			noColor: true,
+		},
+		{
+			name: "delete intent",
+			result: &shell.ExecuteResult{
+				Intent:  "delete",
+				Message: "Deleted task #1",
+			},
+			noColor: true,
+		},
+		{
+			name: "error intent",
+			result: &shell.ExecuteResult{
+				Intent:  "error",
+				Message: "Something went wrong",
+			},
+			noColor: true,
+		},
+		{
+			name: "empty message",
+			result: &shell.ExecuteResult{
+				Intent:  "create",
+				Message: "",
+			},
+			noColor: true,
+		},
+		{
+			name: "with color",
+			result: &shell.ExecuteResult{
+				Intent:  "create",
+				Message: "Created task #1",
+			},
+			noColor: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			display := shell.NewDisplay(tt.noColor)
+
+			// Should not panic
+			display.ShowResult(tt.result)
+		})
+	}
+}
+
+func TestDisplayClear(t *testing.T) {
+	t.Parallel()
+
+	display := shell.NewDisplay(true)
+
+	// Should not panic - outputs ANSI escape codes
+	display.Clear()
+}
+
+func TestDisplayShowResultWithSummary(t *testing.T) {
+	t.Parallel()
+
+	result := &shell.ExecuteResult{
+		Intent:  "create",
+		Message: "Created task #1: Buy milk",
+		Summary: "created task #1",
+		TaskIDs: []int64{1},
+	}
+
+	display := shell.NewDisplay(true)
+
+	// Should not panic
+	display.ShowResult(result)
+}

--- a/internal/shell/scripting_test.go
+++ b/internal/shell/scripting_test.go
@@ -1,0 +1,154 @@
+package shell_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mholtzscher/ugh/internal/shell"
+)
+
+func TestScriptScannerScanLines(t *testing.T) {
+	t.Parallel()
+
+	input := "line1\nline2\nline3"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	want := []string{"line1", "line2", "line3"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(want))
+	}
+	for i, line := range lines {
+		if line != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, line, want[i])
+		}
+	}
+}
+
+func TestScriptScannerLineNumber(t *testing.T) {
+	t.Parallel()
+
+	input := "first\nsecond\nthird"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	expectedLineNums := []int{1, 2, 3}
+	i := 0
+	for scanner.Scan() {
+		if scanner.LineNumber() != expectedLineNums[i] {
+			t.Errorf("line number: got %d, want %d", scanner.LineNumber(), expectedLineNums[i])
+		}
+		i++
+	}
+}
+
+func TestScriptScannerEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	input := ""
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	if scanner.Scan() {
+		t.Error("expected no lines from empty input")
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+}
+
+func TestScriptScannerSingleLine(t *testing.T) {
+	t.Parallel()
+
+	input := "only line"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	if !scanner.Scan() {
+		t.Fatal("expected one line")
+	}
+
+	if scanner.Text() != "only line" {
+		t.Errorf("got %q, want %q", scanner.Text(), "only line")
+	}
+
+	if scanner.LineNumber() != 1 {
+		t.Errorf("line number: got %d, want 1", scanner.LineNumber())
+	}
+
+	if scanner.Scan() {
+		t.Error("expected no more lines")
+	}
+}
+
+func TestScriptScannerWithComments(t *testing.T) {
+	t.Parallel()
+
+	input := "# this is a comment\nactual command\n  # indented comment\n"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	want := []string{"# this is a comment", "actual command", "  # indented comment"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(want))
+	}
+	for i, line := range lines {
+		if line != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, line, want[i])
+		}
+	}
+}
+
+func TestScriptScannerWithBlankLines(t *testing.T) {
+	t.Parallel()
+
+	input := "line1\n\nline2\n\n\nline3"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	want := []string{"line1", "", "line2", "", "", "line3"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(want))
+	}
+	for i, line := range lines {
+		if line != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, line, want[i])
+		}
+	}
+}
+
+func TestScriptScannerWithQuitCommand(t *testing.T) {
+	t.Parallel()
+
+	input := "command1\nquit\ncommand2"
+	scanner := shell.NewScriptScanner(strings.NewReader(input))
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	want := []string{"command1", "quit", "command2"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(want))
+	}
+	for i, line := range lines {
+		if line != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, line, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the shell package:

- **display_test.go**: New test file covering Display component with color/no-color variants, nil result handling, all intent types (create, update, filter, context, help, done, delete, error), and summary display

- **scripting_test.go**: New test file covering ScriptScanner with line scanning, line number tracking, empty input handling, comments, blank lines, and quit command processing

- **executor_test.go**: Extended with 14 new test cases covering:
  - Empty/whitespace command validation
  - LastTaskIDs tracking for create and filter operations
  - SelectedTaskID handling for updates
  - Pronoun substitution (it, this, last, that, selected)
  - Context injection for projects and contexts