### PR TITLE
feat(shell): add prompt autocomplete and syntax highlighting

### DIFF
--- a/internal/nlp/dsl_symbols.go
+++ b/internal/nlp/dsl_symbols.go
@@ -2,5 +2,26 @@ package nlp
 
 import "github.com/alecthomas/participle/v2/lexer"
 
-//nolint:gochecknoglobals // Used by Parseable implementations.
-var dslSymbols map[string]lexer.TokenType = dslLexer.Symbols()
+var (
+	//nolint:gochecknoglobals // Used by Parseable implementations.
+	dslSymbols = dslLexer.Symbols()
+
+	//nolint:gochecknoglobals // Used for debug/introspection helpers.
+	dslSymbolNames = invertSymbolMap(dslSymbols)
+)
+
+func invertSymbolMap(symbols map[string]lexer.TokenType) map[lexer.TokenType]string {
+	out := make(map[lexer.TokenType]string, len(symbols))
+	for name, tt := range symbols {
+		out[tt] = name
+	}
+	return out
+}
+
+func symbolName(tt lexer.TokenType) string {
+	name, ok := dslSymbolNames[tt]
+	if !ok {
+		return ""
+	}
+	return name
+}

--- a/internal/nlp/lex.go
+++ b/internal/nlp/lex.go
@@ -1,0 +1,41 @@
+package nlp
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+// LexToken is a lexer token with symbolic name.
+type LexToken struct {
+	Name  string
+	Value string
+	Pos   lexer.Position
+}
+
+// Lex tokenizes input with the shared DSL lexer.
+func Lex(input string) ([]LexToken, error) {
+	lex, err := dslLexer.LexString("", input)
+	if err != nil {
+		return nil, fmt.Errorf("lex input: %w", err)
+	}
+
+	rawTokens, err := lexer.ConsumeAll(lex)
+	if err != nil {
+		return nil, fmt.Errorf("consume tokens: %w", err)
+	}
+
+	out := make([]LexToken, 0, len(rawTokens))
+	for _, tok := range rawTokens {
+		if tok.EOF() {
+			continue
+		}
+		out = append(out, LexToken{
+			Name:  symbolName(tok.Type),
+			Value: tok.Value,
+			Pos:   tok.Pos,
+		})
+	}
+
+	return out, nil
+}

--- a/internal/nlp/lex_test.go
+++ b/internal/nlp/lex_test.go
@@ -1,0 +1,58 @@
+package nlp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mholtzscher/ugh/internal/nlp"
+)
+
+func TestLexCompleteQuotedStringPrefersQuotedToken(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := nlp.Lex(`add "email #hashtag"`)
+	require.NoError(t, err, "lex error")
+
+	names := tokenNames(tokens)
+	assert.Contains(t, names, "Quoted", "quoted token should be emitted")
+	assert.NotContains(
+		t,
+		names,
+		"QuoteStart",
+		"stateful quote-start token should not be used for complete quoted strings",
+	)
+	assert.NotContains(t, names, "ProjectTag", "hash inside quoted string must not be tokenized as project tag")
+}
+
+func TestLexUnterminatedQuoteStillTokenizes(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := nlp.Lex(`add "email #hashtag`)
+	require.NoError(t, err, "lex error")
+
+	names := tokenNames(tokens)
+	assert.Contains(t, names, "QuoteStart", "unterminated quoted input should emit QuoteStart")
+	assert.Contains(t, names, "StringText", "unterminated quoted input should emit StringText")
+	assert.NotContains(t, names, "ProjectTag", "hash inside open quote must not be tokenized as project tag")
+}
+
+func TestLexTagPrefixes(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := nlp.Lex(`add task # @`)
+	require.NoError(t, err, "lex error")
+
+	names := tokenNames(tokens)
+	assert.Contains(t, names, "ProjectTagPrefix", "standalone # should emit project tag prefix token")
+	assert.Contains(t, names, "ContextTagPrefix", "standalone @ should emit context tag prefix token")
+}
+
+func tokenNames(tokens []nlp.LexToken) []string {
+	names := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		names = append(names, tok.Name)
+	}
+	return names
+}

--- a/internal/nlp/lexer.go
+++ b/internal/nlp/lexer.go
@@ -5,56 +5,71 @@ import (
 )
 
 //nolint:gochecknoglobals // DSL lexer must be a package-level var for participle
-var dslLexer = lexer.MustSimple([]lexer.SimpleRule{
-	// Quoted strings first (highest priority)
-	{Name: "Quoted", Pattern: `"(?:[^"\\]|\\.)*"`},
+var dslLexer = lexer.MustStateful(lexer.Rules{
+	"Root": {
+		// Quoted strings first (highest priority)
+		{Name: "Quoted", Pattern: `"(?:[^"\\]|\\.)*"`},
 
-	// Numeric hash IDs (must come before ProjectTag)
-	{Name: "HashNumber", Pattern: `#[0-9]+`},
+		// Numeric hash IDs (must come before ProjectTag)
+		{Name: "HashNumber", Pattern: `#[0-9]+`},
 
-	// Tags - project (#) and context (@)
-	{Name: "ProjectTag", Pattern: `#[a-zA-Z_][a-zA-Z0-9_-]*`},
-	{Name: "ContextTag", Pattern: `@[a-zA-Z_][a-zA-Z0-9_-]*`},
+		// Tags - project (#) and context (@)
+		{Name: "ProjectTag", Pattern: `#[a-zA-Z_][a-zA-Z0-9_-]*`},
+		{Name: "ContextTag", Pattern: `@[a-zA-Z_][a-zA-Z0-9_-]*`},
 
-	// Field setters with colon (op starters) - MUST come before Ident
-	// These consume the field name and colon together
-	{
-		Name:    "SetField",
-		Pattern: `\b(title|notes|due|waiting|waiting-for|waiting_for|state|project|projects|context|contexts|meta|id|text)\b\s*:`,
+		// Tag prefixes for interactive completion/highlighting
+		{Name: "ProjectTagPrefix", Pattern: `#`},
+		{Name: "ContextTagPrefix", Pattern: `@`},
+
+		// Field setters with colon (op starters) - MUST come before Ident
+		// These consume the field name and colon together
+		{
+			Name:    "SetField",
+			Pattern: `\b(title|notes|due|waiting|waiting-for|waiting_for|state|project|projects|context|contexts|meta|id|text)\b\s*:`,
+		},
+		{
+			Name:    "AddField",
+			Pattern: `\+\s*\b(project|projects|context|contexts|meta)\b\s*:`,
+		},
+		{
+			Name:    "RemoveField",
+			Pattern: `-\s*\b(project|projects|context|contexts|meta)\b\s*:`,
+		},
+		{
+			Name:    "ClearField",
+			Pattern: `!\s*\b(notes|due|waiting|waiting-for|waiting_for|projects|contexts|meta)\b`,
+		},
+
+		// Clear op for non-field cases (just the ! symbol)
+		{Name: "ClearOp", Pattern: `!`},
+
+		// Add/Remove ops as standalone (for tag operations)
+		{Name: "AddOp", Pattern: `\+`},
+		{Name: "RemoveOp", Pattern: `-`},
+
+		// Punctuation
+		{Name: "Colon", Pattern: `:`},
+		{Name: "Comma", Pattern: `,`},
+		{Name: "LParen", Pattern: `\(`},
+		{Name: "RParen", Pattern: `\)`},
+
+		// Logical operators
+		{Name: "AndOp", Pattern: `&&`},
+		{Name: "OrOp", Pattern: `\|\|`},
+
+		// In-progress quoted string support for interactive shell.
+		{Name: "QuoteStart", Pattern: `"`, Action: lexer.Push("String")},
+
+		// Identifiers and words (catch-all for regular words including alphanumeric)
+		{Name: "Ident", Pattern: `[a-zA-Z0-9_-]+`},
+
+		// Whitespace (elided)
+		{Name: "Whitespace", Pattern: `\s+`},
 	},
-	{
-		Name:    "AddField",
-		Pattern: `\+\s*\b(project|projects|context|contexts|meta)\b\s*:`,
+	"String": {
+		{Name: "QuoteEnd", Pattern: `"`, Action: lexer.Pop()},
+		{Name: "StringEscape", Pattern: `\\.`},
+		{Name: "StringText", Pattern: `[^"\\]+`},
+		{Name: "StringBackslash", Pattern: `\\`},
 	},
-	{
-		Name:    "RemoveField",
-		Pattern: `-\s*\b(project|projects|context|contexts|meta)\b\s*:`,
-	},
-	{
-		Name:    "ClearField",
-		Pattern: `!\s*\b(notes|due|waiting|waiting-for|waiting_for|projects|contexts|meta)\b`,
-	},
-
-	// Clear op for non-field cases (just the ! symbol)
-	{Name: "ClearOp", Pattern: `!`},
-
-	// Add/Remove ops as standalone (for tag operations)
-	{Name: "AddOp", Pattern: `\+`},
-	{Name: "RemoveOp", Pattern: `-`},
-
-	// Punctuation
-	{Name: "Colon", Pattern: `:`},
-	{Name: "Comma", Pattern: `,`},
-	{Name: "LParen", Pattern: `\(`},
-	{Name: "RParen", Pattern: `\)`},
-
-	// Logical operators
-	{Name: "AndOp", Pattern: `&&`},
-	{Name: "OrOp", Pattern: `\|\|`},
-
-	// Identifiers and words (catch-all for regular words including alphanumeric)
-	{Name: "Ident", Pattern: `[a-zA-Z0-9_-]+`},
-
-	// Whitespace (elided)
-	{Name: "Whitespace", Pattern: `\s+`},
 })

--- a/internal/nlp/parser_test.go
+++ b/internal/nlp/parser_test.go
@@ -918,6 +918,10 @@ func TestParseErrors(t *testing.T) {
 			name:  "invalid tag token",
 			input: "add task #",
 		},
+		{
+			name:  "unterminated quoted string",
+			input: `add task "email #hashtag`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shell/prompt.go
+++ b/internal/shell/prompt.go
@@ -26,6 +26,10 @@ func NewPrompt(svc service.Service, noColor bool) (*Prompt, error) {
 		Prompt:          promptText,
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",
+		AutoComplete:    newShellCompleter(svc),
+	}
+	if !noColor {
+		cfg.Painter = newShellPainter()
 	}
 
 	rl, err := readline.NewEx(cfg)

--- a/internal/shell/prompt_editor.go
+++ b/internal/shell/prompt_editor.go
@@ -1,0 +1,418 @@
+package shell
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/chzyer/readline"
+
+	"github.com/mholtzscher/ugh/internal/nlp"
+	"github.com/mholtzscher/ugh/internal/service"
+	"github.com/mholtzscher/ugh/internal/store"
+)
+
+const (
+	ansiReset   = "\033[0m"
+	ansiBlue    = "\033[34m"
+	ansiGreen   = "\033[32m"
+	ansiYellow  = "\033[33m"
+	ansiMagenta = "\033[35m"
+	ansiCyan    = "\033[36m"
+)
+
+func commandSuggestions() []string {
+	return []string{
+		"add", "create", "new",
+		"set", "edit", "update",
+		"find", "show", "list", "filter",
+		"context", "view", "help", "clear", "quit", "exit",
+	}
+}
+
+func genericSuggestions() []string {
+	return []string{
+		"title:", "notes:", "due:", "waiting:", "state:",
+		"project:", "projects:", "context:", "contexts:",
+		"+project:", "+context:", "-project:", "-context:",
+		"!due", "!waiting", "!notes",
+		"and", "or", "not", "&&", "||",
+		"today", "tomorrow",
+	}
+}
+
+func stateSuggestions() []string {
+	return []string{"state:inbox", "state:now", "state:waiting", "state:later", "state:done"}
+}
+
+func dueSuggestions() []string {
+	return []string{"due:today", "due:tomorrow"}
+}
+
+type shellCompleter struct {
+	listProjects func(context.Context) ([]string, error)
+	listContexts func(context.Context) ([]string, error)
+}
+
+var _ readline.AutoCompleter = (*shellCompleter)(nil)
+
+func newShellCompleter(svc service.Service) *shellCompleter {
+	return &shellCompleter{
+		listProjects: func(ctx context.Context) ([]string, error) {
+			rows, err := svc.ListProjects(ctx, service.ListTagsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			return extractNames(rows), nil
+		},
+		listContexts: func(ctx context.Context) ([]string, error) {
+			rows, err := svc.ListContexts(ctx, service.ListTagsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			return extractNames(rows), nil
+		},
+	}
+}
+
+func (c *shellCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(line) {
+		pos = len(line)
+	}
+
+	prefixRunes := line[:pos]
+	prefix := string(prefixRunes)
+	tokens, err := nlp.Lex(prefix)
+	if err != nil {
+		return nil, 0
+	}
+	if hasOpenQuote(tokens) {
+		return nil, 0
+	}
+
+	_, fragment := splitFragment(prefixRunes)
+	fragment = strings.TrimSpace(fragment)
+	fragmentLower := strings.ToLower(fragment)
+
+	suggestions := c.suggest(tokens, fragment, fragmentLower)
+	if len(suggestions) == 0 {
+		return nil, 0
+	}
+
+	return toCompletionSuffixes(fragment, suggestions), len([]rune(fragment))
+}
+
+func (c *shellCompleter) suggest(tokens []nlp.LexToken, fragment string, fragmentLower string) []string {
+	nonWhitespace := filterNonWhitespace(tokens)
+	if len(nonWhitespace) == 0 {
+		return filterCandidates(fragment, commandSuggestions())
+	}
+
+	if isContextCommand(nonWhitespace) {
+		return c.contextCommandSuggestions(fragment, fragmentLower)
+	}
+
+	if strings.HasPrefix(fragmentLower, "#") {
+		return filterCandidates(fragment, prefixed(c.projectNames(), "#"))
+	}
+	if strings.HasPrefix(fragmentLower, "@") {
+		return filterCandidates(fragment, prefixed(c.contextNames(), "@"))
+	}
+
+	if strings.HasPrefix(fragmentLower, "state:") {
+		return filterCandidates(fragment, stateSuggestions())
+	}
+	if strings.HasPrefix(fragmentLower, "due:") {
+		return filterCandidates(fragment, dueSuggestions())
+	}
+
+	if fieldPrefix, valuePrefix, ok := splitFieldValuePrefix(fragmentLower); ok {
+		switch fieldPrefix {
+		case "project:", "projects:", "+project:", "+projects:", "-project:", "-projects:":
+			return filterCandidates(fragment, withValuePrefix(fieldPrefix, valuePrefix, c.projectNames()))
+		case "context:", "contexts:", "+context:", "+contexts:", "-context:", "-contexts:":
+			return filterCandidates(fragment, withValuePrefix(fieldPrefix, valuePrefix, c.contextNames()))
+		}
+	}
+
+	if fragment == "" {
+		candidates := append([]string{}, genericSuggestions()...)
+		candidates = append(candidates, prefixed(c.projectNames(), "#")...)
+		candidates = append(candidates, prefixed(c.contextNames(), "@")...)
+		return dedupe(candidates)
+	}
+
+	candidates := append([]string{}, commandSuggestions()...)
+	candidates = append(candidates, genericSuggestions()...)
+	return filterCandidates(fragment, dedupe(candidates))
+}
+
+func (c *shellCompleter) contextCommandSuggestions(fragment string, fragmentLower string) []string {
+	if strings.HasPrefix(fragmentLower, "#") {
+		return filterCandidates(fragment, prefixed(c.projectNames(), "#"))
+	}
+	if strings.HasPrefix(fragmentLower, "@") {
+		return filterCandidates(fragment, prefixed(c.contextNames(), "@"))
+	}
+
+	candidates := []string{"clear"}
+	candidates = append(candidates, prefixed(c.projectNames(), "#")...)
+	candidates = append(candidates, prefixed(c.contextNames(), "@")...)
+	return filterCandidates(fragment, dedupe(candidates))
+}
+
+func (c *shellCompleter) projectNames() []string {
+	if c.listProjects == nil {
+		return nil
+	}
+	names, err := c.listProjects(context.Background())
+	if err != nil {
+		return nil
+	}
+	return sortedUnique(names)
+}
+
+func (c *shellCompleter) contextNames() []string {
+	if c.listContexts == nil {
+		return nil
+	}
+	names, err := c.listContexts(context.Background())
+	if err != nil {
+		return nil
+	}
+	return sortedUnique(names)
+}
+
+func extractNames(rows []store.NameCount) []string {
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.Name) == "" {
+			continue
+		}
+		names = append(names, row.Name)
+	}
+	return names
+}
+
+func prefixed(values []string, prefix string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, prefix+value)
+	}
+	return out
+}
+
+func withValuePrefix(fieldPrefix string, valuePrefix string, values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if valuePrefix != "" && !strings.HasPrefix(strings.ToLower(value), valuePrefix) {
+			continue
+		}
+		out = append(out, fieldPrefix+value)
+	}
+	return out
+}
+
+func filterCandidates(fragment string, candidates []string) []string {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if fragment == "" {
+		return dedupe(candidates)
+	}
+
+	fragmentLower := strings.ToLower(fragment)
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.HasPrefix(strings.ToLower(candidate), fragmentLower) {
+			out = append(out, candidate)
+		}
+	}
+	return dedupe(out)
+}
+
+func dedupe(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func sortedUnique(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	copyValues := dedupe(values)
+	sort.Strings(copyValues)
+	return copyValues
+}
+
+func toCompletionSuffixes(fragment string, fullCandidates []string) [][]rune {
+	fragmentRunes := []rune(fragment)
+	fragLen := len(fragmentRunes)
+	out := make([][]rune, 0, len(fullCandidates))
+	for _, candidate := range fullCandidates {
+		candidateRunes := []rune(candidate)
+		if fragLen > len(candidateRunes) {
+			continue
+		}
+		suffix := candidateRunes[fragLen:]
+		out = append(out, suffix)
+	}
+	return out
+}
+
+func splitFieldValuePrefix(fragmentLower string) (string, string, bool) {
+	idx := strings.Index(fragmentLower, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	field := fragmentLower[:idx+1]
+	valuePrefix := ""
+	if idx+1 < len(fragmentLower) {
+		valuePrefix = fragmentLower[idx+1:]
+	}
+	return field, valuePrefix, true
+}
+
+func isContextCommand(tokens []nlp.LexToken) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	return tokens[0].Name == "Ident" && strings.EqualFold(tokens[0].Value, "context")
+}
+
+func splitFragment(prefix []rune) (int, string) {
+	i := len(prefix)
+	for i > 0 && !isFragmentDelimiter(prefix[i-1]) {
+		i--
+	}
+	return i, string(prefix[i:])
+}
+
+func isFragmentDelimiter(r rune) bool {
+	return unicode.IsSpace(r) || r == '(' || r == ')' || r == ','
+}
+
+func hasOpenQuote(tokens []nlp.LexToken) bool {
+	open := 0
+	for _, tok := range tokens {
+		switch tok.Name {
+		case "QuoteStart":
+			open++
+		case "QuoteEnd":
+			if open > 0 {
+				open--
+			}
+		}
+	}
+	return open > 0
+}
+
+func filterNonWhitespace(tokens []nlp.LexToken) []nlp.LexToken {
+	out := make([]nlp.LexToken, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.Name == "Whitespace" {
+			continue
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+type shellPainter struct{}
+
+var _ readline.Painter = (*shellPainter)(nil)
+
+func newShellPainter() *shellPainter {
+	return &shellPainter{}
+}
+
+func (*shellPainter) Paint(line []rune, _ int) []rune {
+	if len(line) == 0 {
+		return line
+	}
+
+	input := string(line)
+	tokens, err := nlp.Lex(input)
+	if err != nil {
+		return line
+	}
+	if len(tokens) == 0 {
+		return line
+	}
+
+	var b strings.Builder
+	cursor := 0
+	for _, tok := range tokens {
+		start := tok.Pos.Offset
+		if start < cursor || start > len(input) {
+			continue
+		}
+		end := min(start+len(tok.Value), len(input))
+
+		if cursor < start {
+			b.WriteString(input[cursor:start])
+		}
+
+		color := colorForToken(tok)
+		if color == "" {
+			b.WriteString(input[start:end])
+		} else {
+			b.WriteString(color)
+			b.WriteString(input[start:end])
+			b.WriteString(ansiReset)
+		}
+
+		cursor = end
+	}
+	if cursor < len(input) {
+		b.WriteString(input[cursor:])
+	}
+
+	return []rune(b.String())
+}
+
+func colorForToken(tok nlp.LexToken) string {
+	switch tok.Name {
+	case "Quoted", "QuoteStart", "QuoteEnd", "StringText", "StringEscape", "StringBackslash":
+		return ansiYellow
+	case "ProjectTag", "ProjectTagPrefix":
+		return ansiBlue
+	case "ContextTag", "ContextTagPrefix":
+		return ansiGreen
+	case "SetField", "AddField", "RemoveField", "ClearField", "ClearOp", "AddOp", "RemoveOp":
+		return ansiMagenta
+	case "AndOp", "OrOp":
+		return ansiCyan
+	case "HashNumber":
+		return ansiCyan
+	case "Ident":
+		lower := strings.ToLower(tok.Value)
+		if lower == "and" || lower == "or" || lower == "not" {
+			return ansiCyan
+		}
+		if lower == "add" || lower == "create" || lower == "new" ||
+			lower == "set" || lower == "edit" || lower == "update" ||
+			lower == "find" || lower == "show" || lower == "list" || lower == "filter" {
+			return ansiYellow
+		}
+	}
+	return ""
+}

--- a/internal/shell/prompt_editor_test.go
+++ b/internal/shell/prompt_editor_test.go
@@ -1,0 +1,82 @@
+//nolint:testpackage // tests cover unexported prompt helpers.
+package shell
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellCompleterProjectTag(t *testing.T) {
+	t.Parallel()
+
+	completer := &shellCompleter{
+		listProjects: func(context.Context) ([]string, error) {
+			return []string{"work", "home"}, nil
+		},
+		listContexts: func(context.Context) ([]string, error) {
+			return []string{"phone"}, nil
+		},
+	}
+
+	suffixes, offset := completer.Do([]rune("add task #wo"), len([]rune("add task #wo")))
+	require.Equal(t, 3, offset, "offset should match typed # fragment")
+	assert.Contains(t, completionStrings(suffixes), "rk", "#wo should complete to #work")
+}
+
+func TestShellCompleterNoSuggestionsInsideOpenQuote(t *testing.T) {
+	t.Parallel()
+
+	completer := &shellCompleter{
+		listProjects: func(context.Context) ([]string, error) { return []string{"work"}, nil },
+		listContexts: func(context.Context) ([]string, error) { return []string{"phone"}, nil },
+	}
+
+	suffixes, offset := completer.Do([]rune(`add "email #wo`), len([]rune(`add "email #wo`)))
+	assert.Empty(t, suffixes, "should not autocomplete inside an open quote")
+	assert.Zero(t, offset, "offset should be zero when no completions are returned")
+}
+
+func TestShellCompleterStateValue(t *testing.T) {
+	t.Parallel()
+
+	completer := &shellCompleter{}
+	suffixes, offset := completer.Do([]rune("find state:n"), len([]rune("find state:n")))
+
+	require.Equal(t, len([]rune("state:n")), offset, "offset should match field fragment")
+	assert.Contains(t, completionStrings(suffixes), "ow", "state:n should complete to state:now")
+}
+
+func TestShellCompleterContextCommandProject(t *testing.T) {
+	t.Parallel()
+
+	completer := &shellCompleter{
+		listProjects: func(context.Context) ([]string, error) { return []string{"work"}, nil },
+	}
+
+	suffixes, offset := completer.Do([]rune("context #w"), len([]rune("context #w")))
+	require.Equal(t, 2, offset, "offset should match #w fragment")
+	assert.Contains(t, completionStrings(suffixes), "ork", "context #w should complete to #work")
+}
+
+func TestShellPainterHighlightsTokens(t *testing.T) {
+	t.Parallel()
+
+	painter := newShellPainter()
+	line := `add "milk" #work @phone`
+	painted := string(painter.Paint([]rune(line), len([]rune(line))))
+
+	assert.Contains(t, painted, ansiYellow+`"milk"`+ansiReset, "quoted string should be highlighted")
+	assert.Contains(t, painted, ansiBlue+"#work"+ansiReset, "project tag should be highlighted")
+	assert.Contains(t, painted, ansiGreen+"@phone"+ansiReset, "context tag should be highlighted")
+}
+
+func completionStrings(suffixes [][]rune) []string {
+	out := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		out = append(out, string(suffix))
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add readline autocomplete and token painter support to the interactive shell prompt
- switch the NLP lexer to a stateful lexer so incomplete quoted input and standalone tag prefixes can be tokenized safely
- add lexer and prompt editor tests covering quoted strings, tag-prefix completion, and highlight behavior

## Validation
- just check