### PR TITLE
fix(state): normalize task state handling across parsing

### DIFF
--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -1,6 +1,9 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	TaskStateInbox   = "inbox"
@@ -27,6 +30,19 @@ func IsTaskState(value string) bool {
 	default:
 		return false
 	}
+}
+
+// NormalizeState normalizes a state value, handling defaults and aliases.
+// Empty values and "todo" are treated as "inbox".
+func NormalizeState(value string) (string, error) {
+	state := strings.ToLower(strings.TrimSpace(value))
+	if state == "" || state == "todo" {
+		return TaskStateInbox, nil
+	}
+	if !IsTaskState(state) {
+		return "", InvalidStateExpectedError(value)
+	}
+	return state, nil
 }
 
 func InvalidStateExpectedError(value string) error {

--- a/internal/domain/task_test.go
+++ b/internal/domain/task_test.go
@@ -1,0 +1,43 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mholtzscher/ugh/internal/domain"
+)
+
+func TestNormalizeState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to inbox", input: "", want: domain.TaskStateInbox},
+		{name: "todo alias maps to inbox", input: "todo", want: domain.TaskStateInbox},
+		{name: "trim and lowercase", input: "  NOW ", want: domain.TaskStateNow},
+		{name: "valid state passes through", input: "later", want: domain.TaskStateLater},
+		{name: "invalid state", input: "bogus", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := domain.NormalizeState(tc.input)
+			if tc.wantErr {
+				require.Error(t, err, "NormalizeState(%q) should return error", tc.input)
+				return
+			}
+
+			require.NoError(t, err, "NormalizeState(%q) error", tc.input)
+			assert.Equal(t, tc.want, got, "NormalizeState(%q) mismatch", tc.input)
+		})
+	}
+}

--- a/internal/nlp/compile/plan.go
+++ b/internal/nlp/compile/plan.go
@@ -205,7 +205,7 @@ func compilePredicate(pred nlp.Predicate, opts BuildOptions) (nlp.Predicate, err
 
 	switch pred.Kind {
 	case nlp.PredState:
-		state, err := normalizeState(compiled.Text)
+		state, err := domain.NormalizeState(compiled.Text)
 		if err != nil {
 			return nlp.Predicate{}, err
 		}
@@ -252,7 +252,7 @@ func applyCreateSet(req *service.CreateTaskRequest, op nlp.SetOp, now time.Time)
 	case nlp.FieldWaiting:
 		req.WaitingFor = value
 	case nlp.FieldState:
-		state, err := normalizeState(value)
+		state, err := domain.NormalizeState(value)
 		if err != nil {
 			return err
 		}
@@ -335,7 +335,7 @@ func applyUpdateSet(req *service.UpdateTaskRequest, op nlp.SetOp, now time.Time)
 		req.WaitingFor = ptr(value)
 		req.ClearWaitingFor = false
 	case nlp.FieldState:
-		state, err := normalizeState(value)
+		state, err := domain.NormalizeState(value)
 		if err != nil {
 			return err
 		}
@@ -426,17 +426,6 @@ func applyUpdateTag(req *service.UpdateTaskRequest, op nlp.TagOp) {
 		return
 	}
 	req.AddContexts = append(req.AddContexts, strings.TrimSpace(op.Value))
-}
-
-func normalizeState(value string) (string, error) {
-	state := strings.ToLower(strings.TrimSpace(value))
-	if state == "todo" {
-		state = domain.TaskStateInbox
-	}
-	if !domain.IsTaskState(state) {
-		return "", domain.InvalidStateExpectedError(value)
-	}
-	return state, nil
 }
 
 func normalizeDate(value string, now time.Time) (string, error) {

--- a/internal/service/parse.go
+++ b/internal/service/parse.go
@@ -30,12 +30,9 @@ func parseDay(value string) (*time.Time, error) {
 }
 
 func normalizeState(value string) (store.State, error) {
-	value = strings.ToLower(strings.TrimSpace(value))
-	if value == "" {
-		return store.State(domain.TaskStateInbox), nil
+	normalized, err := domain.NormalizeState(value)
+	if err != nil {
+		return "", err
 	}
-	if !domain.IsTaskState(value) {
-		return "", domain.InvalidStateExpectedError(value)
-	}
-	return store.State(value), nil
+	return store.State(normalized), nil
 }

--- a/internal/service/parse_test.go
+++ b/internal/service/parse_test.go
@@ -20,6 +20,7 @@ func TestNormalizeState(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "empty defaults to inbox", input: "", want: store.StateInbox},
+		{name: "todo alias maps to inbox", input: "todo", want: store.StateInbox},
 		{name: "trim and lowercase", input: "  NOW ", want: store.StateNow},
 		{name: "invalid state", input: "bogus", wantErr: true},
 	}


### PR DESCRIPTION
## Summary
- centralize task state normalization in `internal/domain` so service parsing and NLP compilation use the same logic
- treat empty and `todo` state values as `inbox` consistently across create/update/predicate flows
- add coverage for `NormalizeState` at the domain level and extend parser tests for the `todo` alias

Fixes #65