### PR TITLE
fix(shell): reject non-printable control characters in command input

### DIFF
--- a/internal/shell/executor.go
+++ b/internal/shell/executor.go
@@ -52,11 +52,11 @@ func (e *Executor) Execute(ctx context.Context, input string) (*ExecuteResult, e
 		return nil, errors.New("empty command")
 	}
 
-	if badRune, pos, ok := firstDisallowedControlRune(input); ok {
+	if badRune, runePos, ok := firstDisallowedControlRune(input); ok {
 		return nil, fmt.Errorf(
-			"command contains non-printable control character %s at character %d; paste plain text and try again",
+			"command contains non-printable control character %s at rune position %d; paste plain text and try again",
 			formatControlRune(badRune),
-			pos,
+			runePos,
 		)
 	}
 

--- a/internal/shell/executor_test.go
+++ b/internal/shell/executor_test.go
@@ -251,7 +251,21 @@ func TestExecuteRejectsControlCharacters(t *testing.T) {
 	_, err := exec.Execute(context.Background(), "\x16set #1 projects:work")
 	require.Error(t, err, "expected error for control character input")
 	assert.Contains(t, err.Error(), "control character", "error should explain invalid control character")
+	assert.Contains(t, err.Error(), "U+0016", "error should include Unicode control code")
 	assert.Contains(t, err.Error(), `\x16`, "error should include escaped control character")
+	assert.Contains(t, err.Error(), "rune position 1", "error should include 1-based rune position")
+}
+
+func TestExecuteRejectsControlCharactersReportsRunePosition(t *testing.T) {
+	t.Parallel()
+
+	svc := &recordingService{}
+	exec := shell.NewExecutor(svc, &shell.SessionState{}, true)
+
+	_, err := exec.Execute(context.Background(), "é\x16set #1 projects:work")
+	require.Error(t, err, "expected error for control character input")
+	assert.Contains(t, err.Error(), "U+0016", "error should include Unicode control code")
+	assert.Contains(t, err.Error(), "rune position 2", "error should report rune-based position")
 }
 
 func TestExecuteUpdatesLastTaskID(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject command input containing non-printable control characters before preprocessing
- return a clear error that includes the offending character code and position
- add executor test coverage for control-character rejection behavior