### PR TITLE
fix(shell): make calendar view consistent with calendar command

### DIFF
--- a/internal/shell/executor.go
+++ b/internal/shell/executor.go
@@ -347,7 +347,7 @@ func (e *Executor) showViewHelp() *ExecuteResult {
 			"  " + pterm.LightGreen("n, now") + "       Now tasks\n" +
 			"  " + pterm.LightGreen("w, waiting") + "   Waiting tasks\n" +
 			"  " + pterm.LightGreen("l, later") + "     Later tasks\n" +
-			"  " + pterm.LightGreen("c, calendar") + "  Tasks due today\n" +
+			"  " + pterm.LightGreen("c, calendar") + "  Tasks with due dates\n" +
 			"\nUsage: view <name> (e.g., view i or view inbox)"
 	} else {
 		var b strings.Builder
@@ -356,7 +356,7 @@ func (e *Executor) showViewHelp() *ExecuteResult {
 		b.WriteString("  n, now       Now tasks\n")
 		b.WriteString("  w, waiting   Waiting tasks\n")
 		b.WriteString("  l, later     Later tasks\n")
-		b.WriteString("  c, calendar  Tasks due today\n")
+		b.WriteString("  c, calendar  Tasks with due dates\n")
 		b.WriteString("\nUsage: view <name> (e.g., view i or view inbox)")
 		msg = b.String()
 	}

--- a/internal/shell/repl.go
+++ b/internal/shell/repl.go
@@ -226,7 +226,7 @@ func (r *REPL) showPlainHelp() {
 	_, _ = fmt.Fprintln(os.Stdout, "Views:")
 	_, _ = fmt.Fprintln(os.Stdout, "  view i/inbox      Inbox      view n/now        Now")
 	_, _ = fmt.Fprintln(os.Stdout, "  view w/waiting    Waiting    view l/later      Later")
-	_, _ = fmt.Fprintln(os.Stdout, "  view c/calendar   Due today")
+	_, _ = fmt.Fprintln(os.Stdout, "  view c/calendar   Tasks with due dates")
 	_, _ = fmt.Fprintln(os.Stdout, "")
 
 	_, _ = fmt.Fprintln(os.Stdout, "Examples:")
@@ -294,7 +294,7 @@ func (r *REPL) showColorHelp() {
 			pterm.LightGreen("view n/now") + "       Now tasks\n" +
 			pterm.LightGreen("view w/waiting") + "   Waiting tasks\n" +
 			pterm.LightGreen("view l/later") + "     Later tasks\n" +
-			pterm.LightGreen("view c/calendar") + "  Tasks due today")
+			pterm.LightGreen("view c/calendar") + "  Tasks with due dates")
 
 	// Examples panel
 	pterm.DefaultBox.WithTitle(pterm.Green("Examples")).WithRightPadding(1).WithLeftPadding(1).Println(


### PR DESCRIPTION
The `view c/calendar` command now shows all tasks with due dates, matching `ugh calendar` behavior instead of only tasks due today.

Closes #83