### PR TITLE
feat(filter): support wildcard set predicates

### DIFF
--- a/cmd/filter_expr.go
+++ b/cmd/filter_expr.go
@@ -112,5 +112,5 @@ func dueSetExpr(enabled bool) nlp.FilterExpr {
 	if !enabled {
 		return nil
 	}
-	return nlp.Predicate{Kind: nlp.PredDue, Text: ""}
+	return nlp.Predicate{Kind: nlp.PredDue, Text: nlp.FilterWildcard}
 }

--- a/internal/nlp/ast.go
+++ b/internal/nlp/ast.go
@@ -28,6 +28,8 @@ const (
 	viewNameWaiting  = "waiting"
 	viewNameLater    = "later"
 	viewNameCalendar = "calendar"
+
+	FilterWildcard = "*"
 )
 
 type CreateCommand struct {
@@ -138,8 +140,8 @@ type FilterPredicate struct {
 }
 
 type FilterFieldPredicate struct {
-	Field string      `parser:"@SetField"`
-	Value FilterValue `parser:"@@"`
+	Field string       `parser:"@SetField"`
+	Value *FilterValue `parser:"@@?"`
 }
 
 type FilterTagPredicate struct {

--- a/internal/nlp/dsl_parse.go
+++ b/internal/nlp/dsl_parse.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	contextCommandVerb = "context"
+	filterFieldDue     = "due"
 )
 
 func parseIdent(lex *lexer.PeekingLexer) (string, error) {
@@ -266,7 +267,7 @@ func (f *Field) Capture(values []string) error {
 	case "notes":
 		*f = FieldNotes
 		return nil
-	case "due":
+	case filterFieldDue:
 		*f = FieldDue
 		return nil
 	case "waiting", "waiting-for", "waiting_for":
@@ -347,6 +348,7 @@ func isFilterValueDelimiter(tok *lexer.Token) bool {
 func isFilterValueToken(tok *lexer.Token) bool {
 	return tok.Type == dslSymbols["Ident"] ||
 		tok.Type == dslSymbols["HashNumber"] ||
+		tok.Type == dslSymbols["Star"] ||
 		tok.Type == dslSymbols["Colon"] ||
 		tok.Type == dslSymbols["Comma"]
 }

--- a/internal/nlp/lexer.go
+++ b/internal/nlp/lexer.go
@@ -56,6 +56,7 @@ var dslLexer = lexer.MustStateful(lexer.Rules{
 		// Logical operators
 		{Name: "AndOp", Pattern: `&&`},
 		{Name: "OrOp", Pattern: `\|\|`},
+		{Name: "Star", Pattern: `\*`},
 
 		// In-progress quoted string support for interactive shell.
 		{Name: "QuoteStart", Pattern: `"`, Action: lexer.Push("String")},

--- a/internal/shell/executor.go
+++ b/internal/shell/executor.go
@@ -249,7 +249,7 @@ func viewFilterQuery(viewName string) (string, error) {
 	case viewNameLater:
 		return "find state:later", nil
 	case viewNameCalendar:
-		return "find due:", nil
+		return "find due:*", nil
 	default:
 		return "", fmt.Errorf("unknown view: %s", viewName)
 	}

--- a/internal/shell/executor_test.go
+++ b/internal/shell/executor_test.go
@@ -561,6 +561,23 @@ func TestExecuteViewRunsFilterQuery(t *testing.T) {
 	assert.True(t, hasPredicateKind(svc.lastFilter.Filter, nlp.PredState), "filter should include state predicate")
 }
 
+func TestExecuteViewCalendarRunsDueSetFilter(t *testing.T) {
+	t.Parallel()
+
+	svc := &recordingService{}
+	exec := shell.NewExecutor(svc, &shell.SessionState{}, true)
+
+	result, err := exec.Execute(context.Background(), "view calendar")
+	require.NoError(t, err, "execute error")
+	require.NotNil(t, result, "result should not be nil")
+	assert.Equal(t, "filter", result.Intent, "view calendar should execute as filter")
+
+	pred, ok := svc.lastFilter.Filter.(nlp.Predicate)
+	require.True(t, ok, "calendar filter should compile to due predicate, got %T", svc.lastFilter.Filter)
+	assert.Equal(t, nlp.PredDue, pred.Kind, "predicate kind mismatch")
+	assert.Equal(t, nlp.FilterWildcard, pred.Text, "calendar view should filter by any due date")
+}
+
 func TestExecuteViewRespectsStickyContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/filter_sql_builder_test.go
+++ b/internal/store/filter_sql_builder_test.go
@@ -58,15 +58,39 @@ func TestFilterSQLBuilder_InvalidIDReturnsError(t *testing.T) {
 	require.Error(t, err, "Build() should return invalid id error")
 }
 
-func TestFilterSQLBuilder_EmptyDuePredicateHasNoArgs(t *testing.T) {
+func TestFilterSQLBuilder_WildcardDuePredicateHasNoArgs(t *testing.T) {
 	t.Parallel()
 
 	b := &filterSQLBuilder{}
-	clause, args, err := b.Build(nlp.Predicate{Kind: nlp.PredDue, Text: ""})
+	clause, args, err := b.Build(nlp.Predicate{Kind: nlp.PredDue, Text: nlp.FilterWildcard})
 	require.NoError(t, err, "Build() error")
 
 	assert.Contains(t, clause, "t.due_on IS NOT NULL", "clause should contain IS NOT NULL")
 	assert.Contains(t, clause, "t.due_on != ''", "clause should contain non-empty due check")
+	assert.Empty(t, args, "args should be empty")
+}
+
+func TestFilterSQLBuilder_WildcardProjectPredicateHasNoNameArg(t *testing.T) {
+	t.Parallel()
+
+	b := &filterSQLBuilder{}
+	clause, args, err := b.Build(nlp.Predicate{Kind: nlp.PredProject, Text: nlp.FilterWildcard})
+	require.NoError(t, err, "Build() error")
+
+	assert.Contains(t, clause, "task_project_links", "clause should include project link subquery")
+	assert.NotContains(t, clause, "p.name = ?", "clause should not constrain project name")
+	assert.Empty(t, args, "args should be empty")
+}
+
+func TestFilterSQLBuilder_WildcardContextPredicateHasNoNameArg(t *testing.T) {
+	t.Parallel()
+
+	b := &filterSQLBuilder{}
+	clause, args, err := b.Build(nlp.Predicate{Kind: nlp.PredContext, Text: nlp.FilterWildcard})
+	require.NoError(t, err, "Build() error")
+
+	assert.Contains(t, clause, "task_context_links", "clause should include context link subquery")
+	assert.NotContains(t, clause, "c.name = ?", "clause should not constrain context name")
 	assert.Empty(t, args, "args should be empty")
 }
 


### PR DESCRIPTION
## Summary
- add explicit `*` wildcard support for set-style filter predicates (`due`, `project`, `context`)
- reject missing filter values early in NLP post-processing while keeping wildcard as the supported set syntax
- update calendar view query and SQL builder/tests to use wildcard predicates consistently